### PR TITLE
update uffizzi preview actions

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,10 +1,9 @@
 name: Build PR Image
 on:
   pull_request:
-    types: [opened,synchronize,reopened,closed]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
-
   build-application:
     name: Build and Push `f-ui-kit`
     runs-on: ubuntu-latest
@@ -15,7 +14,7 @@ jobs:
       - name: Checkout git repo
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2        
+        uses: docker/setup-buildx-action@v2
       - name: Generate UUID image name
         id: uuid
         run: echo "UUID_TAG_APP=$(uuidgen)" >> $GITHUB_ENV
@@ -40,7 +39,7 @@ jobs:
     name: Render Docker Compose File
     # Pass output of this workflow to another triggered by `workflow_run` event.
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build-application
     outputs:
       compose-file-cache-key: ${{ steps.hash.outputs.hash }}
@@ -61,10 +60,10 @@ jobs:
           path: docker-compose.rendered.yml
           retention-days: 2
       - name: Serialize PR Event to File
-        run:  |
+        run: |
           cat << EOF > event.json
-          ${{ toJSON(github.event) }} 
-          
+          ${{ toJSON(github.event) }}
+
           EOF
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v3
@@ -87,4 +86,3 @@ jobs:
           name: preview-spec
           path: event.json
           retention-days: 2
-

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -9,7 +9,6 @@ on:
     branches-ignore:
       - "main"
 
-
 jobs:
   cache-compose-file:
     name: Cache Compose File
@@ -18,7 +17,7 @@ jobs:
       compose-file-cache-key: ${{ env.COMPOSE_FILE_HASH }}
       pr-number: ${{ env.PR_NUMBER }}
     steps:
-      - name: 'Download artifacts'
+      - name: "Download artifacts"
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
         uses: actions/github-script@v6
         with:
@@ -39,7 +38,7 @@ jobs:
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
-      - name: 'Unzip artifact'
+      - name: "Unzip artifact"
         run: unzip preview-spec.zip
       - name: Read Event into ENV
         run: |
@@ -72,7 +71,7 @@ jobs:
     name: Use Remote Workflow to Preview on Uffizzi
     needs:
       - cache-compose-file
-    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.6.1
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
     with:
       # If this workflow was triggered by a PR close event, cache-key will be an empty string
       # and this reusable workflow will delete the preview deployment.


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Seeing more failures with GitHub actions. We haven't been generating Uffizzi previews and there have been some failures.

We need to update the `UffizziCloud/preview-action/.github/workflows/reusable.yaml` to use `@2` to keep up-to-date with the latest changes to the reusable workflow. We will need to merge this PR into main to confirm the changes. Workflows dispatched by the `workflow_run` event always use the definition in the default branch, which is main for us. 
This change was suggested by the Uffizzi team. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Merge these changes to test.
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
