### PR TITLE
refactor: button stories with icons

### DIFF
--- a/packages/button/stories/DefaultButton.stories.tsx
+++ b/packages/button/stories/DefaultButton.stories.tsx
@@ -31,12 +31,12 @@ export default {
       }
     },
     iconStart: {
-      options: systemIcons,
-      mapping: systemIconLabels
+      options: Object.keys(SystemIcons),
+      mapping: SystemIcons
     },
     iconEnd: {
-      options: systemIcons,
-      mapping: systemIconLabels
+      options: Object.keys(SystemIcons),
+      mapping: SystemIcons
     }
   },
   args: {
@@ -66,15 +66,10 @@ export const _DangerButton = args => (
   <DangerButton {...args}>{args.children}</DangerButton>
 );
 
-export const WithIconBeforeButtonText = args => (
-  <StandardButton iconStart={SystemIcons.Close} {...args}>
-    Icon button
-  </StandardButton>
-);
-
-export const WithIcon = Template.bind({});
-WithIcon.args = {
-  iconStart: SystemIcons.Close
+export const WithIcons = Template.bind({});
+WithIcons.args = {
+  iconStart: SystemIcons.Close,
+  iconEnd: SystemIcons.ArrowRight
 };
 
 export const IconOnly = Template.bind({});


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Monica pointed out that we have two stories here that are essentially the same - Thanks Monica! 
I've consolidated them down to a `WithIcons` story that displays the `iconStart` and `iconEnd` together.
I've found a better way to configure the icon-related controls so that we can display all of the available system icons and it will have a label that is similar to how it would be used by a developer ie the key `ArrowUp` vs the value `"system-icons-arrow-up"`.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Test out the icon controls on the "With Icons" story. You can test through the Uffizzi preview or run Storybook locally.
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
<img width="1481" alt="Screen Shot 2022-12-09 at 8 54 01 AM" src="https://user-images.githubusercontent.com/34781875/206729553-ab908f2c-16ec-4a54-ba1f-87ded29f3e09.png">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
