### PR TITLE
feat: make appchrome props optional

### DIFF
--- a/packages/appChrome/components/AppChrome.tsx
+++ b/packages/appChrome/components/AppChrome.tsx
@@ -19,12 +19,35 @@ import {
 } from "./HeaderBar";
 
 export interface AppChromeProps {
-  sidebar: React.ReactNode;
-  headerBar: React.ReactNode;
-  mainContent: React.ReactNode;
+  /**
+   * Optional className to apply to outermost div
+   */
+  className?: string;
+  /**
+   * JSX to render along the left side
+   */
+  sidebar?: React.ReactNode;
+  /**
+   * JSX to render as the navigation bar at the top
+   */
+  headerBar?: React.ReactNode;
+  /**
+   * @deprecated This prop should not be used, use children instead
+   */
+  mainContent?: React.ReactNode;
+  /**
+   * JSX for the main html element
+   */
+  children?: React.ReactNode;
 }
 
-const AppChrome = ({ sidebar, headerBar, mainContent }: AppChromeProps) => {
+const AppChrome = ({
+  className,
+  sidebar,
+  headerBar,
+  mainContent,
+  children
+}: AppChromeProps) => {
   return (
     <ThemeProvider
       theme={{
@@ -36,19 +59,27 @@ const AppChrome = ({ sidebar, headerBar, mainContent }: AppChromeProps) => {
       }}
     >
       <div
-        className={cx(appChrome, textSize("m"), flex({ direction: "column" }))}
+        className={cx(
+          appChrome,
+          textSize("m"),
+          flex({ direction: "column" }),
+          className
+        )}
         data-cy="appChrome"
       >
-        <div data-cy="headerBar">{headerBar}</div>
+        {headerBar && <div data-cy="headerBar">{headerBar}</div>}
         <div className={cx(flex(), appWrapper)}>
-          <div className={flexItem("shrink")} data-cy="sidebar">
-            {sidebar}
-          </div>
+          {sidebar && (
+            <div className={flexItem("shrink")} data-cy="sidebar">
+              {sidebar}
+            </div>
+          )}
           <main
             className={cx(flexItem("grow"), flush("left"), appWrapper)}
             data-cy="main"
           >
             {mainContent}
+            {children}
           </main>
         </div>
       </div>


### PR DESCRIPTION
Allows for someone to use just the header or sidebar without needing to declare both. Also add children prop and deprecates mainContent because its a lot easier to use with children, as it allows JSX to simply be nested rather than part of a prop. Found these while trying to use this component during innovation days.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
