### PR TITLE
fix: make var check ssr friendly

### DIFF
--- a/packages/utilities/getCSSVarValue.ts
+++ b/packages/utilities/getCSSVarValue.ts
@@ -1,10 +1,14 @@
 const getCSSVarValue = cssVar => {
-  if (document.documentElement !== null) {
-    // Get the content between the parentheses in "var()"
-    // and split the args from a string to an array
-    const cssVarArgsString = cssVar.match(/\(([^)]+)\)/)[1];
-    const cssVarArgs = cssVarArgsString.replace(/\s/g, "").split(",");
+  // Get the content between the parentheses in "var()"
+  // and split the args from a string to an array
+  const cssVarArgsString = cssVar.match(/\(([^)]+)\)/)[1];
+  const cssVarArgs = cssVarArgsString.replace(/\s/g, "").split(",");
 
+  if (typeof window === "undefined") {
+    return cssVarArgs[1];
+  }
+
+  if (document?.documentElement !== null) {
     // If there's a custom property defined on :root (<html>), return that.
     // Otherwise, return the fallback value.
     return (


### PR DESCRIPTION
document and window are not defined in node environments, so trying to use ui-kit with an isomorphic framework like next will fail saying document/window is not defined. Adding a check that window is not undefined before trying to operate on document seems to fix the issue. There may be more places like this in ui-kit but this is all I've run up against so far.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
