### PR TITLE
fix: react tabs focus styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-focus-lock": "2.9.2",
         "react-id-generator": "3.0.2",
         "react-popper": "2.3.0",
-        "react-tabs": "5.1.0",
+        "react-tabs": "6.0.0",
         "react-transition-group": "4.4.5",
         "relative-luminance": "2.0.1"
       },
@@ -31818,9 +31818,9 @@
       }
     },
     "node_modules/react-tabs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-5.1.0.tgz",
-      "integrity": "sha512-jsPVEPuhG7JljTo8Q4ujz4UKRpG90nHlDClAdvV5KrLxCHU+MT/kg7dmhq8fDv8+frciDtaYeFFlTVRLm4N5AQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.0.tgz",
+      "integrity": "sha512-8jKLKrlwxmn5/+xsa76yi27ZdB8E/WhlhQZw739O5UlOeUGtVoVeWnpqIewv/KbjTw7gQf/uA51zWUNt4IVygQ==",
       "dependencies": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"
@@ -60719,9 +60719,9 @@
       }
     },
     "react-tabs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-5.1.0.tgz",
-      "integrity": "sha512-jsPVEPuhG7JljTo8Q4ujz4UKRpG90nHlDClAdvV5KrLxCHU+MT/kg7dmhq8fDv8+frciDtaYeFFlTVRLm4N5AQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.0.tgz",
+      "integrity": "sha512-8jKLKrlwxmn5/+xsa76yi27ZdB8E/WhlhQZw739O5UlOeUGtVoVeWnpqIewv/KbjTw7gQf/uA51zWUNt4IVygQ==",
       "requires": {
         "clsx": "^1.1.0",
         "prop-types": "^15.5.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-focus-lock": "2.9.2",
     "react-id-generator": "3.0.2",
     "react-popper": "2.3.0",
-    "react-tabs": "5.1.0",
+    "react-tabs": "6.0.0",
     "react-transition-group": "4.4.5",
     "relative-luminance": "2.0.1"
   },

--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -43,9 +43,15 @@ injectGlobal`
   }
 }
 
-.react-tabs__tab:focus {
-  outline: none;
-  background: ${themeBgHover}
+/* Focusing on tabs with a mouse will not display an outline */
+.react-tabs__tab:focus:not(:focus-visible)   {
+  outline: 0;
+}
+
+/* Focusing tabs with a keyboard will add a light gray background color */
+.react-tabs__tab:focus-visible {
+  outline: 0;
+  background-color: ${themeBgHover}
 }
 
 .react-tabs__tab--selected {
@@ -147,6 +153,7 @@ const Tabs = ({
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       onSelect={onSelect ? onSelect : () => {}}
       data-cy="tabs"
+      focusTabOnClick={false}
     >
       <TabList>{tabs}</TabList>
       {tabsContent}


### PR DESCRIPTION
Closes D2IQ-94906

<!-- PR Checklist -->

# Description

### Background on the Issue
This initial issue arose from noticing a gray background on Tab Items in the UI after they've been clicked on. After looking into this issue, I discovered this behavior was coming from the `:focus` style set for the Tabs component upstream. It was an intentional style decision to handle keyboard navigation to display active focus.

### `:focus` vs `:focus-visible`
After looking into the functionality of the `:focus` pseudo-class. I discovered `:focus-visible` which applies the style when elements are interacted with via keyboard and not with pointer-events such as mouse clicks. This seemed like the perfect resolution for our situation. We do not want the gray background on click but we do want it for keyboard navigation to preserve accessibility.

Resource: [The :focus-visible Trick](https://css-tricks.com/the-focus-visible-trick/)

### React Tabs
After implementing `:focus-visible` over `:focus` I noticed there was inconsistent behavior where it would still apply the gray background on click. I googled around a bit and found a related [open issue with react-tabs](https://github.com/reactjs/react-tabs/issues/390). I noticed we were a major version behind on react-tabs. I updated that to see if it would resolve the issue, however it persisted. I ended up digging more into the react-tabs documentation and I found there were specific features of the component that were contributing to the unexpected focus behavior. 
The main culprit seemed to be `focusTabOnClick` which is by default set to true. 

> By default, the tab that is clicked will also be focused in the DOM. If set to false the tab will not be focused anymore.

Setting this property to false seemed to do the trick, and if you click the tab key keyboard navigation can still be initiated again. This change paired with using `:focus-visible` should prevent the not-so-aesthetically-pleasing gray background for pointer-events while maintaining proper accessibility features with keyboard navigation.

### Outline Discoveries
Another change you'll see is where I set `outline: 0` instead of `outline: none`. I was looking into the differences between these two as I've seen both used in the past. Thought I would share what I learned there.

According to [MDN](https://developer.mozilla.org/en/docs/Web/CSS/outline):

> The CSS outline property is a shorthand property for setting one or more of the individual outline properties outline-style, outline-width and outline-color in a single declaration

[More detail on this question on StackOverflow.](https://stackoverflow.com/questions/35648667/outline-none-vs-outline-0)

> The only difference is the outline-width:
> 
> When the outline is 0, the outline-width is 0px
> When the outline is none, the outline-width is medium
> That is the only difference between the two. You can use either one, they will both display the same way (since the outline-style is none, it does not matter how wide the outline is).
> 

Another comment mentioned this:

I opted for `outline: 0;` and I had to set it in both selector locations to prevent the focus ring outline.

Further reading on outline and focus accessibility: http://www.outlinenone.com/


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Interact with the Tabs component with keyboard navigation (tabs and arrows) compared to clicking on tabs.
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

### Tabs with keyboard navigation

![tab-keyboard-nav](https://user-images.githubusercontent.com/34781875/208510795-00245e76-f206-4795-a50c-04f8717d54f9.gif)

### Tabs with mouse clicks
![tabs](https://user-images.githubusercontent.com/34781875/208510813-f23007f0-1ccb-427e-94ae-6a045cb5fa60.gif)

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [x] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
