### PR TITLE
feat: inlineloadingindicator custom props

### DIFF
--- a/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
@@ -1,12 +1,31 @@
 import * as React from "react";
 import { Icon } from "../../icon";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import { IconSize } from "../../shared/types/iconSize";
 
-const InlineLoadingIndicator = () => (
+const DEFAULT_ICON_SIZE: IconSize = "xs";
+
+export interface InlineLoadingIndicatorProps {
+  /**
+   * The fill color of the spinner.
+   */
+  color?: string;
+  /** Which icon size to use for the width and height of the icon. */
+  size?: IconSize;
+  /** Human-readable selector used for writing tests. */
+  "data-cy"?: string;
+}
+
+const InlineLoadingIndicator = ({
+  size = DEFAULT_ICON_SIZE,
+  "data-cy": dataCy = "inlineLoadingIndicator",
+  color = "inherit"
+}) => (
   <Icon
     shape={SystemIcons.Spinner}
-    size="xs"
-    data-cy="inlineLoadingIndicator"
+    size={size}
+    data-cy={dataCy}
+    color={color}
   />
 );
 

--- a/packages/loadingIndicator/stories/InlineLoadingIndicator.stories.tsx
+++ b/packages/loadingIndicator/stories/InlineLoadingIndicator.stories.tsx
@@ -9,33 +9,48 @@ import {
 } from "../../configurationmap";
 
 import { InlineLoadingIndicator } from "..";
+import { spacingSizeValues } from "../../storybookHelpers/controlConstants";
 
 export default {
   title: "Feedback/Loading Indicators/Inline Loading Indicator",
-  component: InlineLoadingIndicator
+  component: InlineLoadingIndicator,
+  argTypes: {
+    color: {
+      control: { type: "color" }
+    },
+    size: {
+      options: spacingSizeValues,
+      control: {
+        type: "select"
+      }
+    },
+    "data-cy": {
+      control: { disable: true }
+    }
+  }
 } as Meta;
 
-const Template: Story = args => (
-  <>
-    <ConfigurationMap>
-      <ConfigurationMapSection>
-        <ConfigurationMapRow>
-          <ConfigurationMapLabel>Name</ConfigurationMapLabel>
-          <ConfigurationMapValue>
-            <InlineLoadingIndicator {...args} />
-          </ConfigurationMapValue>
-        </ConfigurationMapRow>
-        <ConfigurationMapRow>
-          <ConfigurationMapLabel>Role</ConfigurationMapLabel>
-          <ConfigurationMapValue>UX Designer</ConfigurationMapValue>
-        </ConfigurationMapRow>
-        <ConfigurationMapRow>
-          <ConfigurationMapLabel>City</ConfigurationMapLabel>
-          <ConfigurationMapValue>San Francisco</ConfigurationMapValue>
-        </ConfigurationMapRow>
-      </ConfigurationMapSection>
-    </ConfigurationMap>
-  </>
-);
+const Template: Story = args => <InlineLoadingIndicator {...args} />;
 
 export const Default = Template.bind({});
+
+export const InlineWithinComponent = args => (
+  <ConfigurationMap>
+    <ConfigurationMapSection>
+      <ConfigurationMapRow>
+        <ConfigurationMapLabel>Name</ConfigurationMapLabel>
+        <ConfigurationMapValue>
+          <InlineLoadingIndicator {...args} />
+        </ConfigurationMapValue>
+      </ConfigurationMapRow>
+      <ConfigurationMapRow>
+        <ConfigurationMapLabel>Role</ConfigurationMapLabel>
+        <ConfigurationMapValue>UX Designer</ConfigurationMapValue>
+      </ConfigurationMapRow>
+      <ConfigurationMapRow>
+        <ConfigurationMapLabel>City</ConfigurationMapLabel>
+        <ConfigurationMapValue>San Francisco</ConfigurationMapValue>
+      </ConfigurationMapRow>
+    </ConfigurationMapSection>
+  </ConfigurationMap>
+);

--- a/packages/loadingIndicator/tests/__snapshots__/loadingIndicator.test.tsx.snap
+++ b/packages/loadingIndicator/tests/__snapshots__/loadingIndicator.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Loading indicators renders SectionLoadingIndicator 1`] = `
 <DocumentFragment>
   <svg
     aria-label="system-spinner icon"
-    class="css-jbdp75"
+    class="css-1naj4ae"
     data-cy="icon inlineLoadingIndicator"
     height="16"
     preserveAspectRatio="xMinYMin meet"


### PR DESCRIPTION
Introduces custom color, size, and data-cy props.

<!-- PR Checklist -->

# Description

Previous to these changes our `InlineLoadingIndicator` component has been pretty rigid. It would only be the black/default/inherited color. You could not customize the size or color. 
After these changes, we can customize this component's color, size, and data-cy while maintaining the previous defaults. 
This allows for a more extensible component.

I've also fixed up the stories here. It's easier to see the component's code block, customize controls, and see the component on its own as a default.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Check out the stories in the Uffizzi link. 
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
<img width="1030" alt="Screen Shot 2022-12-20 at 11 58 15 AM" src="https://user-images.githubusercontent.com/34781875/208741811-1b94d16e-edac-440b-b3c8-b5b6b3fc2b52.png">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
