### PR TITLE
[1] refactor: add data-cy and classname props

### DIFF
--- a/packages/accordion/components/AccordionItem.tsx
+++ b/packages/accordion/components/AccordionItem.tsx
@@ -5,13 +5,16 @@ import { Provider as AccordionItemProvider } from "./AccordionItemContext";
 
 export interface AccordionItemProps {
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * A custom ID for the accordion panel
    */
   id?: string;
+  /**
+   * Allows custom styling
+   */
   className?: string;
   children?: React.ReactNode;
 }

--- a/packages/accordion/components/AccordionItemContent.tsx
+++ b/packages/accordion/components/AccordionItemContent.tsx
@@ -12,13 +12,16 @@ import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtil
 
 interface AccordionItemContentProps {
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
-   * the amount of space between the border and the content
+   * The amount of space between the border and the content
    */
   paddingSize?: SpaceSize;
+  /**
+   * Allows custom styling
+   */
   className?: string;
   children: React.ReactNode;
 }

--- a/packages/accordion/components/AccordionItemTitle.tsx
+++ b/packages/accordion/components/AccordionItemTitle.tsx
@@ -16,9 +16,9 @@ export interface AccordionItemTitleProps {
    */
   appearance?: AccordionTitleAppearances;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * Whether the accordion item can be expanded
    */
@@ -27,6 +27,9 @@ export interface AccordionItemTitleProps {
    * Priority of the heading. Numbers map to <h1> through <h6>
    */
   headingLevel?: HeadingLevel;
+  /**
+   * Allows custom styling
+   */
   className?: string;
   children: React.ReactNode;
 }

--- a/packages/accordion/components/AccordionItemTitleInner.tsx
+++ b/packages/accordion/components/AccordionItemTitleInner.tsx
@@ -8,10 +8,19 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { fillWidth, accordionTitleInteractive } from "../style";
 
 export interface AccordionItemTitleInnerProps {
+  /**
+   * Wether the accordion item is expanded by default
+   */
   isExpanded?: boolean;
+  /**
+   * Wether the accordion is responsive to interaction
+   */
   isInteractive?: boolean;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
   children: React.ReactNode;
-  ["data-cy"]?: string;
 }
 
 const AccordionItemTitleInner = ({

--- a/packages/accordion/components/AccordionItemTitleInteractive.tsx
+++ b/packages/accordion/components/AccordionItemTitleInteractive.tsx
@@ -24,9 +24,9 @@ interface RenderProps {
 const AccordionItemTitleInteractive = ({
   appearance,
   children,
-  "data-cy": dataCy,
+  "data-cy": dataCy = "accordionItemTitle",
   disabled,
-  headingLevel,
+  headingLevel = 3,
   className
 }: Omit<AccordionItemTitleProps, "children"> & {
   children: (renderProps: RenderProps) => React.ReactNode;
@@ -94,11 +94,6 @@ const AccordionItemTitleInteractive = ({
       </AccordionItemTitleInner>
     </AccordionItemTitleOuter>
   );
-};
-
-AccordionItemTitleInteractive.defaultProps = {
-  headingLevel: 3,
-  "data-cy": "accordionItemTitle"
 };
 
 export default AccordionItemTitleInteractive;

--- a/packages/accordion/components/AccordionItemTitleOuter.tsx
+++ b/packages/accordion/components/AccordionItemTitleOuter.tsx
@@ -13,7 +13,7 @@ interface AccordionItemTitleOuterProps {
   appearance?: AccordionTitleAppearances;
   disabled?: boolean;
   isExpanded?: boolean;
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   children?: React.ReactNode;
 }
 

--- a/packages/accordion/types.ts
+++ b/packages/accordion/types.ts
@@ -6,9 +6,9 @@ export interface AccordionBaseProps {
    */
   allowMultipleExpanded?: boolean;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * A function that gets called when an accordion item is expanded or closed
    */

--- a/packages/appChrome/components/AppChrome.tsx
+++ b/packages/appChrome/components/AppChrome.tsx
@@ -20,7 +20,7 @@ import {
 
 export interface AppChromeProps {
   /**
-   * Optional className to apply to outermost div
+   * Allows custom styling
    */
   className?: string;
   /**
@@ -39,6 +39,10 @@ export interface AppChromeProps {
    * JSX for the main html element
    */
   children?: React.ReactNode;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const AppChrome = ({
@@ -46,7 +50,8 @@ const AppChrome = ({
   sidebar,
   headerBar,
   mainContent,
-  children
+  children,
+  "data-cy": dataCy = "appChrome"
 }: AppChromeProps) => {
   return (
     <ThemeProvider
@@ -65,7 +70,7 @@ const AppChrome = ({
           flex({ direction: "column" }),
           className
         )}
-        data-cy="appChrome"
+        data-cy={dataCy}
       >
         {headerBar && <div data-cy="headerBar">{headerBar}</div>}
         <div className={cx(flex(), appWrapper)}>

--- a/packages/avatar/components/Avatar.tsx
+++ b/packages/avatar/components/Avatar.tsx
@@ -23,19 +23,24 @@ export interface AvatarProps {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const Avatar = ({
   label,
   src,
   className,
-  size = DEFAULT_AVATAR_SIZE
+  size = DEFAULT_AVATAR_SIZE,
+  "data-cy": dataCy = "avatar"
 }: AvatarProps) => (
   <div
     className={cx(avatarContainer, avatarSize(iconSizes[size]), className)}
     role="img"
     aria-label={label}
-    data-cy="avatar"
+    data-cy={dataCy}
   >
     {/* Intentionally not setting "alt" so it doesn't appear in the avatar box
     when/if src is empty or a broken URL */}

--- a/packages/badge/components/badge.tsx
+++ b/packages/badge/components/badge.tsx
@@ -11,21 +11,29 @@ export type BadgeAppearance =
   | "outline";
 
 export interface BadgeProps {
+  /**
+   * Sets the style of the badge
+   */
   appearance?: BadgeAppearance;
   children: React.ReactNode | string;
   /**
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 export const Badge = ({
   appearance = "default",
   children,
-  className
+  className,
+  "data-cy": dataCy = "badge"
 }: BadgeProps) => {
   return (
-    <span className={cx(badge(appearance), className)} data-cy="badge">
+    <span className={cx(badge(appearance), className)} data-cy={dataCy}>
       {children}
     </span>
   );

--- a/packages/badge/components/badgeButton.tsx
+++ b/packages/badge/components/badgeButton.tsx
@@ -23,7 +23,10 @@ export interface BadgeButtonProps {
    */
   tabIndex?: number;
   children: React.ReactNode[] | React.ReactNode;
-  ["data-cy"]?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const BadgeButton = ({

--- a/packages/breadcrumb/components/Breadcrumb.tsx
+++ b/packages/breadcrumb/components/Breadcrumb.tsx
@@ -11,15 +11,26 @@ import {
 } from "../../shared/styles/styleUtils";
 
 export interface BreadcrumbProps {
-  className?: string;
   children?: React.ReactNode | string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 function intersperse<A>(list: A[], sep: JSX.Element) {
   return Array.prototype.concat(...list.map(e => [sep, e])).slice(1);
 }
 
-const Breadcrumb = ({ className, children }: BreadcrumbProps) => {
+const Breadcrumb = ({
+  className,
+  children,
+  "data-cy": dataCy = "breadcrumb"
+}: BreadcrumbProps) => {
   const breadcrumbSeparator = <Icon shape={SystemIcons.CaretRight} size="xs" />;
   const crumbsArr = intersperse(
     React.Children.toArray(children),
@@ -34,7 +45,7 @@ const Breadcrumb = ({ className, children }: BreadcrumbProps) => {
           className={cx(textWeight("medium"), textSize("l"), {
             [padding("left", "xs")]: i !== 0
           })}
-          data-cy="breadcrumb"
+          data-cy={dataCy}
         >
           {crumb}
         </div>

--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -34,11 +34,11 @@ export enum ButtonAppearances {
 
 export interface ButtonProps extends LinkProps {
   /**
-   * if the button triggers new content to appear (e.g.: modals and dropdowns)
+   * If the button triggers new content to appear (e.g.: modals and dropdowns)
    */
   ariaHaspopup?: boolean;
   /**
-   * should be used if the button does not contain text children. For example: a button that is just an icon
+   * Should be used if the button does not contain text children. For example: a button that is just an icon
    */
   ariaLabel?: string;
   children?: React.ReactNode | string;
@@ -47,47 +47,51 @@ export interface ButtonProps extends LinkProps {
    */
   className?: string;
   /**
-   * whether or not the button is enabled
+   * Whether or not the button is enabled
    */
   disabled?: boolean;
   /**
-   * the icon that appears before the button text
+   * The icon that appears before the button text
    */
   // TODO: only accept IconShapes when we make a big breaking change
   iconStart?: IconShapes | React.ReactElement<HTMLElement>;
   /**
-   * the icon that appears after the button text
+   * The icon that appears after the button text
    */
   // TODO: only accept IconShapes when we make a big breaking change
   iconEnd?: IconShapes | React.ReactElement<HTMLElement>;
   /**
-   * whether the action the button was meant to do has completed
+   * Whether the action the button was meant to do has completed
    */
   isProcessing?: boolean;
   /**
-   * if the button should fill the width of it's container
+   * If the button should fill the width of it's container
    */
   isFullWidth?: boolean;
   /**
-   * if the button is on a dark background
+   * If the button is on a dark background
    */
   isInverse?: boolean;
   /**
-   * the function that is called when the button loses focus
+   * The function that is called when the button loses focus
    */
   onBlur?: (e?: React.SyntheticEvent<HTMLElement>) => void;
   /**
-   * the function that is called when the button gets focus
+   * The function that is called when the button gets focus
    */
   onFocus?: (e?: React.SyntheticEvent<HTMLElement>) => void;
   /**
-   * the function that is called when the button is "clicked" via cursor, touch, or keyboard
+   * The function that is called when the button is "clicked" via cursor, touch, or keyboard
    */
   onClick?: (e?: React.SyntheticEvent<HTMLElement>) => void;
   /**
-   * the type of button - same as HTML "type" attribute on the <button> tag
+   * The type of button matching the HTML "type" attribute on the <button> tag
    */
   type?: "button" | "reset" | "submit";
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 export interface ButtonBaseProps extends ButtonProps {

--- a/packages/card/components/ButtonCard.tsx
+++ b/packages/card/components/ButtonCard.tsx
@@ -41,6 +41,7 @@ const ButtonCard = ({
   onClick,
   className,
   onKeyPress,
+  "data-cy": dataCy = "buttonCard",
   ...other
 }: ButtonCardProps) => {
   const tabIndex = disabled ? -1 : 0;
@@ -81,7 +82,7 @@ const ButtonCard = ({
         className
       )}
       {...buttonProps}
-      data-cy="buttonCard"
+      data-cy={dataCy}
       {...other}
     />
   );

--- a/packages/card/components/Card.tsx
+++ b/packages/card/components/Card.tsx
@@ -45,6 +45,10 @@ export interface CardProps extends React.HTMLProps<HTMLDivElement> {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const Card = ({
@@ -53,6 +57,7 @@ const Card = ({
   aspectRatio,
   paddingSize = "m",
   header,
+  "data-cy": dataCy = "card",
   ...other
 }: CardProps) => {
   const headerSize = header?.size || HeaderSizes.M;
@@ -64,7 +69,7 @@ const Card = ({
   return (
     <div
       className={cx(cardBase, aspectRatioStyle, className)}
-      data-cy="card"
+      data-cy={dataCy}
       {...other}
     >
       {header?.headerImg && (

--- a/packages/clickable/components/clickable.tsx
+++ b/packages/clickable/components/clickable.tsx
@@ -24,9 +24,9 @@ export interface ClickableProps {
    */
   disableFocusOutline?: boolean;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
 }
 
 export const Clickable = ({
@@ -52,7 +52,7 @@ export const Clickable = ({
     role,
     tabIndex,
     onKeyPress: handleKeyPress,
-    ["data-cy"]: dataCy
+    "data-cy": dataCy
   });
 };
 

--- a/packages/configurationmap/components/ConfigurationMapValue.tsx
+++ b/packages/configurationmap/components/ConfigurationMapValue.tsx
@@ -5,17 +5,17 @@ import { ddReset } from "../../shared/styles/styleUtils/resets/definitionListRes
 
 interface ConfigurationMapValueProps {
   children: React.ReactNode;
-  dataCy?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const ConfigurationMapValue = ({
   children,
-  dataCy
+  "data-cy": dataCy = "configurationMapValue"
 }: ConfigurationMapValueProps) => (
-  <div
-    className={cx(ddReset, flexItem("grow"), breakWord)}
-    data-cy={dataCy ?? "configurationMapValue"}
-  >
+  <div className={cx(ddReset, flexItem("grow"), breakWord)} data-cy={dataCy}>
     {children}
   </div>
 );

--- a/packages/donutChart/components/DonutChart.tsx
+++ b/packages/donutChart/components/DonutChart.tsx
@@ -14,27 +14,45 @@ interface DonutChartDatum {
 
 export interface DonutChartProps {
   /**
-   * objects that define the size and color of segments in the donut chart
+   * Objects that define the size and color of segments in the donut chart
    */
   data: DonutChartDatum[];
   /**
-   * the primary piece of data in the chart - appears large
+   * The primary piece of data in the chart - appears large
    */
   label?: string;
   /**
-   * a caption for the label
+   * A caption for the label
    */
   text?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
 }
 
-const DonutChart = ({ data, label, text }: DonutChartProps) => {
+const DonutChart = ({
+  data,
+  label,
+  text,
+  className,
+  "data-cy": dataCy = "donutChart"
+}: DonutChartProps) => {
   const strokeWidth = 1.5;
   const radius = 100 / (Math.PI * 2);
   const diameter = radius * 2 + strokeWidth;
   const circleCenter = diameter / 2;
 
   return (
-    <svg viewBox={`0 0 ${diameter} ${diameter}`} data-cy="donutChart">
+    <svg
+      viewBox={`0 0 ${diameter} ${diameter}`}
+      data-cy={dataCy}
+      className={className}
+    >
       <circle
         cx={circleCenter}
         cy={circleCenter}

--- a/packages/dropdownMenu/components/DropdownMenu.tsx
+++ b/packages/dropdownMenu/components/DropdownMenu.tsx
@@ -65,7 +65,7 @@ export interface DropdownMenuProps {
    */
   menuMaxWidth?: React.CSSProperties["maxWidth"];
   /**
-   * callback for when a menu item is clicked
+   * Callback for when a menu item is clicked
    */
   onSelect?: (
     selectedItem: string,
@@ -74,7 +74,7 @@ export interface DropdownMenuProps {
     >
   ) => void;
   /**
-   * which DOM node the dropdown menu will attach to
+   * Which DOM node the dropdown menu will attach to
    */
   overlayRoot?: HTMLElement;
   /**
@@ -89,6 +89,9 @@ export interface DropdownMenuProps {
    * Whether the dropdown node should be portalled to document.body, or open in it's parent DOM node
    */
   disablePortal?: boolean;
+  /**
+   * Allows custom styling
+   */
   className?: string;
 }
 
@@ -105,7 +108,14 @@ const DropdownMenu = (props: DropdownMenuProps) => {
     menuMaxWidth,
     onSelect,
     overlayRoot,
-    preferredDirections,
+    preferredDirections = [
+      Direction.BottomRight,
+      Direction.BottomLeft,
+      Direction.BottomCenter,
+      Direction.TopRight,
+      Direction.TopCenter,
+      Direction.TopLeft
+    ],
     trigger
   } = props;
 
@@ -222,17 +232,6 @@ const DropdownMenu = (props: DropdownMenuProps) => {
       )}
     </Downshift>
   );
-};
-
-DropdownMenu.defaultProps = {
-  preferredDirections: [
-    Direction.BottomRight,
-    Direction.BottomLeft,
-    Direction.BottomCenter,
-    Direction.TopRight,
-    Direction.TopCenter,
-    Direction.TopLeft
-  ]
 };
 
 export default DropdownMenu;

--- a/packages/list/components/BorderedList.tsx
+++ b/packages/list/components/BorderedList.tsx
@@ -4,22 +4,22 @@ import { cx } from "@emotion/css";
 import { SharedListProps } from "./List";
 import { listReset } from "../../shared/styles/styleUtils";
 
-const BorderedList = (props: SharedListProps) => {
-  const { tag, children } = props;
+const BorderedList = ({
+  tag = "ul",
+  children,
+  className,
+  "data-cy": dataCy = "borderedList"
+}: SharedListProps) => {
   const BorderedListEl = tag;
 
   return (
     <BorderedListEl
-      className={cx(listReset, borderedListStyle)}
-      data-cy="borderedList"
+      className={cx(listReset, borderedListStyle, className)}
+      data-cy={dataCy}
     >
       {children}
     </BorderedListEl>
   );
-};
-
-BorderedList.defaultProps = {
-  tag: "ul"
 };
 
 export default BorderedList;

--- a/packages/list/components/List.tsx
+++ b/packages/list/components/List.tsx
@@ -7,7 +7,18 @@ export interface SharedListProps {
   children:
     | Array<React.ReactElement<HTMLLIElement>>
     | React.ReactElement<HTMLLIElement>;
+  /**
+   * Set to an ordered list `ol` or the defaulted unordered list `ul`
+   */
   tag: "ul" | "ol";
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
 }
 
 interface ListProps extends SharedListProps {
@@ -26,20 +37,23 @@ interface ListProps extends SharedListProps {
     | "none";
 }
 
-const List = (props: ListProps) => {
-  const { children, markerStyle, tag } = props;
+const List = ({
+  children,
+  className,
+  markerStyle = "none",
+  tag = "ul",
+  "data-cy": dataCy = "list"
+}: ListProps) => {
   const ListEl = tag;
 
   return (
-    <ListEl className={cx(listReset, listMarker(markerStyle))} data-cy="list">
+    <ListEl
+      className={cx(listReset, listMarker(markerStyle), className)}
+      data-cy={dataCy}
+    >
       {children}
     </ListEl>
   );
-};
-
-List.defaultProps = {
-  markerStyle: "none",
-  tag: "ul"
 };
 
 export default List;

--- a/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
@@ -1,4 +1,4 @@
-import { css } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import * as React from "react";
 import { greyLight } from "../../design-tokens/build/js/designTokens";
 import { sectionLoadingWrapper, sectionLoadingIndicator } from "../style";
@@ -6,13 +6,25 @@ import { sectionLoadingWrapper, sectionLoadingIndicator } from "../style";
 export interface SectionLoadingIndicatorProps {
   /** Custom color for the loading indicator */
   color?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
 }
 
-const SectionLoadingIndicator = ({ color }: SectionLoadingIndicatorProps) => {
+const SectionLoadingIndicator = ({
+  color,
+  className,
+  "data-cy": dataCy = "sectionLoadingIndicator"
+}: SectionLoadingIndicatorProps) => {
   return (
-    <div className={sectionLoadingWrapper}>
+    <div className={cx(sectionLoadingWrapper, className)}>
       <div
-        data-cy="sectionLoadingIndicator"
+        data-cy={dataCy}
         className={css(sectionLoadingIndicator, {
           backgroundColor: color || greyLight
         })}

--- a/packages/messagePanel/components/MessagePanel.tsx
+++ b/packages/messagePanel/components/MessagePanel.tsx
@@ -26,20 +26,25 @@ export interface MessagePanelProps {
    * A secondary action a user can take in the empty state
    */
   secondaryAction?: React.ReactNode;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
   children: React.ReactNode;
 }
 
 const MessagePanel = ({
-  appearance,
+  appearance = "standard",
   heading,
   children,
   primaryAction,
-  secondaryAction
+  secondaryAction,
+  "data-cy": dataCy = "messagePanel"
 }: MessagePanelProps) => {
   const hasActions = primaryAction || secondaryAction;
 
   return (
-    <div className={messagePanelContainer} data-cy="messagePanel">
+    <div className={messagePanelContainer} data-cy={dataCy}>
       <Card paddingSize="xxl">
         <SpacingBox side="bottom" spacingSize="xs">
           <HeadingText2 align="center">
@@ -83,10 +88,6 @@ const MessagePanel = ({
       </Card>
     </div>
   );
-};
-
-MessagePanel.defaultProps = {
-  appearance: "standard"
 };
 
 export default MessagePanel;

--- a/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
@@ -35,12 +35,12 @@ exports[`MessagePanel appearance='error' 1`] = `
                 xlink:href="#system-circle-close"
               />
             </svg>
-            <span
+            <div
               class="css-m1scup"
               data-cy="spacingBox"
             >
               Heading
-            </span>
+            </div>
           </h2>
         </div>
         <div

--- a/packages/styleUtils/modifiers/components/BorderedBox.tsx
+++ b/packages/styleUtils/modifiers/components/BorderedBox.tsx
@@ -25,20 +25,22 @@ export interface BorderedBoxProps extends BoxProps {
 }
 
 const BorderedBox = (props: BorderedBoxProps) => {
-  const { side, radius, variant, className, ...other } = props;
+  const {
+    side,
+    radius = "none",
+    variant,
+    className,
+    "data-cy": dataCy = "borderedBox",
+    ...other
+  } = props;
 
   return (
     <Box
       className={cx(className, border(side, variant), borderRadius(radius))}
-      data-cy="borderedBox"
+      data-cy={dataCy}
       {...other}
     />
   );
-};
-
-BorderedBox.defaultProps = {
-  radius: "none",
-  tag: "div"
 };
 
 export default BorderedBox;

--- a/packages/styleUtils/modifiers/components/Box.tsx
+++ b/packages/styleUtils/modifiers/components/Box.tsx
@@ -40,11 +40,11 @@ export interface BoxProps {
   /**
    * Which HTML tag to render the component with
    */
-  tag: keyof React.ReactHTML;
+  tag?: keyof React.ReactHTML;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   children?: React.ReactNode;
   className?: string;
 }
@@ -53,14 +53,18 @@ const Box = (props: BoxProps) => {
   const {
     bgColor,
     bgImageUrl,
-    bgImageOptions,
+    bgImageOptions = {
+      size: undefined,
+      position: undefined,
+      repeat: undefined
+    },
     display,
     vertAlignChildren,
     isVisuallyHidden,
     textAlign,
-    tag,
+    tag = "div",
     className,
-    "data-cy": dataCy,
+    "data-cy": dataCy = "box",
     ...other
   } = props;
   const getBgImageOptionVal = (option: "size" | "position" | "repeat") =>
@@ -96,12 +100,6 @@ const Box = (props: BoxProps) => {
   return (
     <BoxEl className={cx(boxStyles, className)} data-cy={dataCy} {...other} />
   );
-};
-
-Box.defaultProps = {
-  bgImageOptions: { size: undefined, position: undefined, repeat: undefined },
-  tag: "div" as keyof React.ReactHTML,
-  "data-cy": "box"
 };
 
 export default Box;

--- a/packages/styleUtils/modifiers/components/SpacingBox.tsx
+++ b/packages/styleUtils/modifiers/components/SpacingBox.tsx
@@ -20,14 +20,20 @@ export interface SpacingBoxProps extends BoxProps {
    * Used to set different spacing values on different sides of the element
    */
   spacingSizePerSide?: { [Side in NonNullable<BoxSides>]?: SpaceSize };
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const SpacingBox = (props: SpacingBoxProps) => {
   const {
     side = "all",
-    spacingSize,
+    spacingSize = "m",
     className,
     spacingSizePerSide,
+    "data-cy": dataCy = "spacingBox",
+    tag = "div",
     ...other
   } = props;
   const paddingStyles = spacingSizePerSide
@@ -40,18 +46,8 @@ const SpacingBox = (props: SpacingBoxProps) => {
     : padding(side, spacingSize);
 
   return (
-    <Box
-      className={cx(className, paddingStyles)}
-      data-cy="spacingBox"
-      {...other}
-    />
+    <Box className={cx(className, paddingStyles)} data-cy={dataCy} {...other} />
   );
-};
-
-SpacingBox.defaultProps = {
-  side: "all",
-  spacingSize: "m",
-  tag: "div"
 };
 
 export default SpacingBox;

--- a/packages/utilities/label.tsx
+++ b/packages/utilities/label.tsx
@@ -29,6 +29,7 @@ export interface RenderLabelProps {
   label?: React.ReactNode;
   required?: boolean;
   tooltipContent?: React.ReactNode;
+  "data-cy"?: string;
 }
 
 export const renderLabel = ({
@@ -37,7 +38,8 @@ export const renderLabel = ({
   label,
   id = nextId(),
   required,
-  tooltipContent
+  tooltipContent,
+  "data-cy": dataCy = "textInput-label"
 }: RenderLabelProps) => {
   const hasError = appearance === InputAppearance.Error;
   const labelClassName = hidden ? cx(visuallyHidden) : getLabelStyle(hasError);
@@ -45,7 +47,7 @@ export const renderLabel = ({
     <label
       className={labelClassName}
       htmlFor={id}
-      data-cy="textInput-label"
+      data-cy={dataCy}
       hidden={hidden}
     >
       {label}


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Throughout these changes I am looking to achieve the following:
- Add `data-cy` attributes that we will be able to pass in custom values. Improving DX with our components + Cypress testing. I have opted for consistent use of `"data-cy"` instead of `["data-cy"]` as the [] is unnecessary. 
- Add `className` to an outermost container on components, that we can use for style overrides in the future.
- Consistency in the casing of prop definitions, as this displays to the Storybook UI in the Docs tab.
- Remove unnecessary `defaultProps` and opt for default values set during prop destructuring. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
