### PR TITLE
[2] refactor: add data-cy and classname props

### DIFF
--- a/packages/accordion/components/AccordionItemTitleInner.tsx
+++ b/packages/accordion/components/AccordionItemTitleInner.tsx
@@ -9,11 +9,11 @@ import { fillWidth, accordionTitleInteractive } from "../style";
 
 export interface AccordionItemTitleInnerProps {
   /**
-   * Wether the accordion item is expanded by default
+   * Whether the accordion item is expanded by default
    */
   isExpanded?: boolean;
   /**
-   * Wether the accordion is responsive to interaction
+   * Whether the accordion is responsive to interaction
    */
   isInteractive?: boolean;
   /**

--- a/packages/card/components/LinkCard.tsx
+++ b/packages/card/components/LinkCard.tsx
@@ -11,6 +11,10 @@ export interface ButtonCardProps extends CardProps {
    * What screenreaders read aloud for the link
    */
   linkDescription: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const LinkCard = ({
@@ -19,12 +23,13 @@ const LinkCard = ({
   url,
   children,
   className,
+  "data-cy": dataCy = "linkCard",
   ...other
 }: ButtonCardProps & LinkProps) => {
   return (
     <Card
       className={cx(buttonCard, cardWithLink, className)}
-      data-cy="linkCard"
+      data-cy={dataCy}
       {...other}
     >
       <>

--- a/packages/formStructure/components/FormMessage.tsx
+++ b/packages/formStructure/components/FormMessage.tsx
@@ -5,12 +5,17 @@ import { SpacingBox } from "../../styleUtils/modifiers";
 
 type FormMessageProps = Omit<InfoBoxProps, "message">;
 
-const FormMessage = ({ children, className, ...other }: FormMessageProps) => (
+const FormMessage = ({
+  children,
+  className,
+  "data-cy": dataCy = "formMessage",
+  ...other
+}: FormMessageProps) => (
   <SpacingBox
     className={className}
     side="bottom"
     spacingSize="l"
-    data-cy="formMessage"
+    data-cy={dataCy}
   >
     <InfoBoxInline message={children} {...other} />
   </SpacingBox>

--- a/packages/formStructure/components/FormSection.tsx
+++ b/packages/formStructure/components/FormSection.tsx
@@ -7,14 +7,22 @@ export interface FormSectionProps {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
-const FormSection = ({ children, className }: FormSectionProps) => (
+const FormSection = ({
+  children,
+  className,
+  "data-cy": dataCy = "formSection"
+}: FormSectionProps) => (
   <SpacingBox
     className={className}
     side="bottom"
     spacingSize="xl"
-    data-cy="formSection"
+    data-cy={dataCy}
   >
     {children}
   </SpacingBox>

--- a/packages/formStructure/components/FormSectionFooter.tsx
+++ b/packages/formStructure/components/FormSectionFooter.tsx
@@ -7,15 +7,18 @@ export interface FormSectionFooterProps {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
-const FormSectionFooter = ({ children, className }: FormSectionFooterProps) => (
-  <SpacingBox
-    className={className}
-    side="top"
-    spacingSize="m"
-    data-cy="formSectionFooter"
-  >
+const FormSectionFooter = ({
+  children,
+  className,
+  "data-cy": dataCy = "formSectionFooter"
+}: FormSectionFooterProps) => (
+  <SpacingBox className={className} side="top" spacingSize="m" data-cy={dataCy}>
     {children}
   </SpacingBox>
 );

--- a/packages/formStructure/components/FormSectionHeader.tsx
+++ b/packages/formStructure/components/FormSectionHeader.tsx
@@ -7,20 +7,31 @@ interface FormSectionHeaderProps {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Title text
+   */
   title: string;
+  /**
+   * Subtitle text
+   */
   subtitle?: React.ReactNode;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const FormSectionHeader = ({
   className,
   title,
-  subtitle
+  subtitle,
+  "data-cy": dataCy = "formSectionHeader"
 }: FormSectionHeaderProps) => (
   <SpacingBox
     className={className}
     side="bottom"
     spacingSize="m"
-    data-cy="formSectionHeader"
+    data-cy={dataCy}
   >
     <HeadingText2 data-cy="formSectionHeader-title">{title}</HeadingText2>
     {subtitle && (

--- a/packages/formStructure/components/FormTitle.tsx
+++ b/packages/formStructure/components/FormTitle.tsx
@@ -8,11 +8,19 @@ export interface FormTitleProps {
    * Allows custom styling
    */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
-const FormTitle = ({ children, className }: FormTitleProps) => (
+const FormTitle = ({
+  children,
+  className,
+  "data-cy": dataCy = "formTitle"
+}: FormTitleProps) => (
   <SpacingBox className={className} side="bottom" spacingSize="l">
-    <HeadingText1 data-cy="formTitle">{children}</HeadingText1>
+    <HeadingText1 data-cy={dataCy}>{children}</HeadingText1>
   </SpacingBox>
 );
 

--- a/packages/icon/components/Icon.tsx
+++ b/packages/icon/components/Icon.tsx
@@ -32,9 +32,9 @@ export interface IconProps {
    */
   size?: IconSize;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * Sets display to block if true
    */

--- a/packages/infobox/components/InfoBox.tsx
+++ b/packages/infobox/components/InfoBox.tsx
@@ -20,29 +20,33 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
 export interface InfoBoxProps {
   /**
-   * the tone of the message
+   * The style and tone of the message
    */
   appearance?: "danger" | "default" | "info" | "success" | "warning";
   /**
-   * additional styles to extend the component
+   * Additional styles to extend the component
    */
   className?: string;
   /**
-   * additional styles to extend the component
+   * Additional styles to extend the component
    */
   onDismiss?: (event?: React.SyntheticEvent<HTMLElement>) => void;
   /**
-   * the main content of the message
+   * The main content of the message
    */
   message: React.ReactNode;
   /**
-   * the more prominent action presented to the user
+   * The more prominent action presented to the user
    */
   primaryAction?: React.ReactElement<HTMLElement>;
   /**
-   * an alternate action the user could take
+   * An alternate action the user could take
    */
   secondaryAction?: React.ReactElement<HTMLElement>;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
   children?: React.ReactNode | React.ReactNode[];
 }
 

--- a/packages/messagePanel/components/MessagePanelWithGraphic.tsx
+++ b/packages/messagePanel/components/MessagePanelWithGraphic.tsx
@@ -19,6 +19,10 @@ interface MessagePanelWithGraphicProps extends MessagePanelProps {
    * The expected width and/or height dimensions of the graphic
    */
   graphicDimensions?: GraphicDimensions;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const MessagePanelWithGraphic = ({
@@ -27,11 +31,12 @@ const MessagePanelWithGraphic = ({
   heading,
   children,
   primaryAction,
-  secondaryAction
+  secondaryAction,
+  "data-cy": dataCy = "messagePanelWithGraphic"
 }: MessagePanelWithGraphicProps) => {
   const hasActions = primaryAction || secondaryAction;
   return (
-    <div data-cy="messagePanelWithGraphic">
+    <div data-cy={dataCy}>
       <SpacingBox spacingSize="xl" side="bottom">
         <img
           src={graphicSrc}

--- a/packages/modal/components/FullscreenModal.tsx
+++ b/packages/modal/components/FullscreenModal.tsx
@@ -5,18 +5,37 @@ import { ButtonProps } from "../../button/components/ButtonBase";
 import FullscreenView from "../../fullscreenView/components/FullscreenView";
 
 interface FullscreenModalProps extends ModalBaseProps {
-  /** The primary button */
+  /**
+   * The primary button used for a call to action
+   */
   ctaButton?: React.ReactElement<ButtonProps>;
-  /** The text for the secondary button that closes the modal */
+  /**
+   * The text for the button that closes the modal
+   */
   closeText: React.ReactNode;
-  /** The title that appears in the header */
+
+  /**
+   * The title that appears in the header
+   */
   title: React.ReactNode;
-  /** The subtitle that appears in the header */
+  /**
+   * The subtitle that appears in the header
+   */
   subtitle?: React.ReactNode;
-  /** Whether we automatically add padding to the body of the modal. */
+  /**
+   * Whether we automatically add padding to the body of the modal.
+   */
   isContentFlush?: boolean;
-  /** Custom header content component. ⚠️Use rarely and with caution⚠️ */
+  /**   */
+  /**
+   * Custom header content component.
+   * ⚠️ Use rarely and with caution
+   */
   headerComponent?: React.JSXElementConstructor<any>;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const FullscreenModal = ({
@@ -28,6 +47,7 @@ const FullscreenModal = ({
   title,
   subtitle,
   headerComponent,
+  "data-cy": dataCy = "fullscreenModal",
   ...other
 }: FullscreenModalProps) => {
   return (
@@ -35,7 +55,7 @@ const FullscreenModal = ({
       size={ModalSizes.Fullscreen}
       onClose={onClose}
       isAnimated={false}
-      data-cy="fullscreenModal"
+      data-cy={dataCy}
       {...other}
     >
       <FullscreenView

--- a/packages/modal/components/ModalBase.tsx
+++ b/packages/modal/components/ModalBase.tsx
@@ -25,34 +25,58 @@ export enum ModalSizes {
 
 export interface ModalBaseProps {
   children?: React.ReactNode;
-  /** Controls whether the modal animates in and out. ⚠️Do not use this directly⚠️ */
+  /**
+   * Controls whether the modal animates in and out
+   * ⚠️ Do not use this directly
+   */
   isAnimated?: boolean;
-  /** Whether the modal is open */
+  /**
+   * Whether the modal is open or not
+   */
   isOpen: boolean;
-  /** A selector for which element gets focus when the modal opens. Uses `document.querySelector` under the hood */
+  /**
+   * A selector for which element gets focus when the modal opens. Uses `document.querySelector` under the hood
+   */
   initialFocus?: string;
-  /** Function that gets called when the modal is closed */
+  /**
+   * Function called when the modal is closed
+   */
   onClose: (event?: React.SyntheticEvent<HTMLElement>) => void;
-  /** Which size modal to render. ⚠️Do not use this directly⚠️ */
+  /**
+   * Which size modal to render
+   * ⚠️ Do not use this directly
+   */
   size?: ModalSizes;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
-   * which DOM node the modal will attach to
+   * Which DOM node the modal will attach to
    */
   overlayRoot?: HTMLElement;
   /**
-   * the ID attribute that is passed to the modal dialog box
+   * The ID attribute that is passed to the modal dialog box
    */
   id?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
 }
 
 const animationDuration = 250;
 
 const ModalBase = ({ isAnimated = true, ...props }: ModalBaseProps) => {
-  const { children, size, isOpen, "data-cy": dataCy, overlayRoot, id } = props;
+  const {
+    children,
+    size,
+    isOpen,
+    "data-cy": dataCy,
+    overlayRoot,
+    id,
+    className
+  } = props;
   const modalSize = size || ModalSizes.M;
 
   const onKeyDown = e => {
@@ -98,10 +122,15 @@ const ModalBase = ({ isAnimated = true, ...props }: ModalBaseProps) => {
               />
               <div className={centerDialogWrapper}>
                 <div
-                  className={cx(modal, modalWidth[modalSize], {
-                    [modalPreTransitionStyle(animationDuration)]: isAnimated,
-                    [modalTransitionStyles[state]]: isAnimated
-                  })}
+                  className={cx(
+                    modal,
+                    modalWidth[modalSize],
+                    {
+                      [modalPreTransitionStyle(animationDuration)]: isAnimated,
+                      [modalTransitionStyles[state]]: isAnimated
+                    },
+                    className
+                  )}
                   role="dialog"
                   onKeyDown={onKeyDown}
                   tabIndex={-1}

--- a/packages/modal/components/ModalContents.tsx
+++ b/packages/modal/components/ModalContents.tsx
@@ -3,15 +3,32 @@ import { cx } from "@emotion/css";
 import { modalWrapper } from "../style";
 import { flex } from "../../shared/styles/styleUtils";
 export interface ModalContentsProps {
+  /**
+   * Whether the modal is open or not
+   */
   isOpen: boolean;
+  /**
+   * Function called when the modal is closed
+   */
   onClose: () => void;
+  /**
+   * Human-readable selector used for writing tests
+   */
   "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
   children?: React.ReactNode | React.ReactNode[];
 }
 
-const ModalContents = ({ children, "data-cy": dataCy }: ModalContentsProps) => (
+const ModalContents = ({
+  children,
+  "data-cy": dataCy,
+  className
+}: ModalContentsProps) => (
   <div
-    className={cx(modalWrapper, flex({ direction: "column" }))}
+    className={cx(modalWrapper, flex({ direction: "column" }), className)}
     data-cy={dataCy}
   >
     {children}

--- a/packages/pageheader/components/PageHeader.tsx
+++ b/packages/pageheader/components/PageHeader.tsx
@@ -27,7 +27,7 @@ export interface PageHeaderProps {
    */
   "data-cy"?: string;
   /**
-   * Pass in custom CSS properties.
+   * Allows custom styles.
    */
   className?: string;
   children?: React.ReactNode;

--- a/packages/popover/components/Popover.tsx
+++ b/packages/popover/components/Popover.tsx
@@ -22,23 +22,27 @@ export interface PopoverProps
    * Whether the dropdown starts open
    */
   initialIsOpen?: boolean;
-  /** The maximum height of the dropdown overlay, represented by number of pixels. */
+  /**
+   * The maximum height of the dropdown overlay, represented by number of pixels.
+   */
   maxHeight?: number;
-  /** The maximum width of the dropdown overlay, represented by number of pixels. */
+  /**
+   * The maximum width of the dropdown overlay, represented by number of pixels
+   */
   maxWidth?: number;
   /**
    * The node that opens the menu when clicked
    */
   trigger: React.ReactNode;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
 }
 
 const Popover = ({
   children,
-  "data-cy": dataCy,
+  "data-cy": dataCy = "popover",
   id,
   initialIsOpen,
   maxHeight,
@@ -161,10 +165,6 @@ const Popover = ({
       </Dropdownable>
     </div>
   );
-};
-
-Popover.defaultProps = {
-  ["data-cy"]: "popover"
 };
 
 export default Popover;

--- a/packages/popover/components/PopoverBox.tsx
+++ b/packages/popover/components/PopoverBox.tsx
@@ -13,6 +13,7 @@ export interface PopoverProps extends React.HTMLProps<HTMLDivElement> {
   menuRef?: React.RefObject<HTMLDivElement>;
   showPointerCaret?: boolean;
   width?: React.CSSProperties["width"];
+  "data-cy"?: string;
 }
 
 const Popover = (props: PopoverProps) => {
@@ -23,6 +24,7 @@ const Popover = (props: PopoverProps) => {
     menuRef,
     showPointerCaret,
     width,
+    "data-cy": dataCy = "popover",
     ...other
   } = props;
   return (
@@ -35,7 +37,7 @@ const Popover = (props: PopoverProps) => {
         })}
         ref={menuRef}
         style={{ width, maxHeight, maxWidth }}
-        data-cy="popover"
+        data-cy={dataCy}
         {...other}
       />
       {showPointerCaret && <div className={getPopoverBoxArrow(direction)} />}

--- a/packages/popover/components/PopoverListItem.tsx
+++ b/packages/popover/components/PopoverListItem.tsx
@@ -29,6 +29,7 @@ export interface PopoverListItemProps extends React.HTMLProps<HTMLDivElement> {
   listLength: number;
   isActive?: boolean;
   isSelected?: boolean;
+  "data-cy"?: string;
 }
 
 const PopoverListItem = (props: PopoverListItemProps) => {
@@ -39,6 +40,7 @@ const PopoverListItem = (props: PopoverListItemProps) => {
     index,
     listLength,
     children,
+    "data-cy": dataCy = "PopoverListItem",
     ...other
   } = props;
   // Importing these was causing issues with `getCSSVarValue` where it would
@@ -126,7 +128,7 @@ const PopoverListItem = (props: PopoverListItemProps) => {
           [tintContent(themeError)]: appearance === "danger"
         }
       )}
-      data-cy="PopoverListItem"
+      data-cy={dataCy}
       {...other}
     >
       {itemGraphicStart || itemGraphicEnd ? (

--- a/packages/promo/types.ts
+++ b/packages/promo/types.ts
@@ -17,8 +17,8 @@ export interface PromoProps {
   primaryAction?: React.ReactNode;
   /** An additional action a user can take in response to the banner's message. This can also just be a link to more information relevant to the banner's message. */
   secondaryAction?: React.ReactNode;
-  /** The Cypress selector */
-  ["data-cy"]?: string;
+  /** Human-readable selector used for writing tests */
+  "data-cy"?: string;
 }
 
 export type GradientStyle = "lightBlue" | "purple" | "oceanBlue";

--- a/packages/styleUtils/layout/flexbox/components/Flex.tsx
+++ b/packages/styleUtils/layout/flexbox/components/Flex.tsx
@@ -21,9 +21,9 @@ export interface FlexProps extends FlexboxProperties {
    */
   tag?: keyof React.ReactHTML;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   children?: React.ReactNode | React.ReactNode[];
 }
 

--- a/packages/styleUtils/layout/flexbox/components/FlexItem.tsx
+++ b/packages/styleUtils/layout/flexbox/components/FlexItem.tsx
@@ -31,9 +31,9 @@ interface FlexItemProps {
    */
   tag?: keyof React.ReactHTML;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   children?: React.ReactNode | React.ReactNode[];
 }
 

--- a/packages/styleUtils/layout/gridList/components/GridList.tsx
+++ b/packages/styleUtils/layout/gridList/components/GridList.tsx
@@ -27,13 +27,11 @@ export interface GridListProps {
   /**
    * Additional styles to extend the component.
    */
-
   className?: string;
-
   /**
    * Human-readable selector used for writing tests.
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * Centers grid children by implementing `place-items: center;` Optimal for grids that could have a state with only 1 grid child.
    */


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Throughout these changes I am looking to achieve the following:
- Add `data-cy` attributes that we will be able to pass in custom values. Improving DX with our components + Cypress testing. I have opted for consistent use of `"data-cy"` instead of `["data-cy"]` as the [] is unnecessary. 
- Add `className` to an outermost container on components, that we can use for style overrides in the future.
- Consistency in the casing of prop definitions, as this displays to the Storybook UI in the Docs tab.
- Remove unnecessary `defaultProps` and opt for default values set during prop destructuring. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
