### PR TITLE
[3] refactor: add data-cy and classname props

### DIFF
--- a/packages/appChrome/components/SidebarSection.tsx
+++ b/packages/appChrome/components/SidebarSection.tsx
@@ -15,14 +15,25 @@ import { AppChromeTheme } from "../types";
 
 export interface SidebarSectionProps {
   children: React.ReactNode | React.ReactNode[];
+  /**
+   * Will appear in the header of the sidebar section
+   */
   label?: React.ReactElement<HTMLElement> | string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
-const SidebarSection = ({ label, children }: SidebarSectionProps) => {
+const SidebarSection = ({
+  label,
+  children,
+  "data-cy": dataCy = "sidebarSection"
+}: SidebarSectionProps) => {
   const theme: AppChromeTheme = useTheme();
 
   return (
-    <div data-cy="sidebarSection">
+    <div data-cy={dataCy}>
       {label && (
         <h3
           className={cx(

--- a/packages/button/components/DangerButton.tsx
+++ b/packages/button/components/DangerButton.tsx
@@ -8,7 +8,7 @@ import {
 const DangerButton = (props: ButtonProps) => (
   <ButtonBase
     appearance={ButtonAppearances.Danger}
-    data-cy="dangerButton"
+    data-cy={props["data-cy"] ?? "dangerButton"}
     {...props}
   />
 );

--- a/packages/button/components/DangerDropdownButton.tsx
+++ b/packages/button/components/DangerDropdownButton.tsx
@@ -6,7 +6,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 const DangerDropdownButton = (props: ButtonProps) => (
   <DangerButton
     iconEnd={SystemIcons.TriangleDown}
-    data-cy="dangerDropdownButton"
+    data-cy={props["data-cy"] ?? "dangerDropdownButton"}
     {...props}
   />
 );

--- a/packages/button/components/PrimaryButton.tsx
+++ b/packages/button/components/PrimaryButton.tsx
@@ -9,7 +9,7 @@ import { LinkProps } from "../../link/types";
 const PrimaryButton = (props: ButtonProps & LinkProps) => (
   <ButtonBase
     appearance={ButtonAppearances.Primary}
-    data-cy="primaryButton"
+    data-cy={props["data-cy"] ?? "primaryButton"}
     {...props}
   />
 );

--- a/packages/button/components/PrimaryDropdownButton.tsx
+++ b/packages/button/components/PrimaryDropdownButton.tsx
@@ -6,7 +6,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 const PrimaryDropdownButton = (props: ButtonProps) => (
   <PrimaryButton
     iconEnd={SystemIcons.TriangleDown}
-    data-cy="primaryDropdownButton"
+    data-cy={props["data-cy"] ?? "primaryDropdownButton"}
     {...props}
   />
 );

--- a/packages/button/components/SecondaryButton.tsx
+++ b/packages/button/components/SecondaryButton.tsx
@@ -8,7 +8,7 @@ import {
 const SecondaryButton = (props: ButtonProps) => (
   <ButtonBase
     appearance={ButtonAppearances.Secondary}
-    data-cy="secondaryButton"
+    data-cy={props["data-cy"] ?? "secondaryButton"}
     {...props}
   />
 );

--- a/packages/button/components/SecondaryDropdownButton.tsx
+++ b/packages/button/components/SecondaryDropdownButton.tsx
@@ -6,7 +6,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 const SecondaryDropdownButton = (props: ButtonProps) => (
   <SecondaryButton
     iconEnd={SystemIcons.TriangleDown}
-    data-cy="secondaryDropdownButton"
+    data-cy={props["data-cy"] ?? "secondaryDropdownButton"}
     {...props}
   />
 );

--- a/packages/button/components/StandardButton.tsx
+++ b/packages/button/components/StandardButton.tsx
@@ -9,7 +9,7 @@ import { LinkProps } from "../../link/types";
 const StandardButton = (props: ButtonProps & LinkProps) => (
   <ButtonBase
     appearance={ButtonAppearances.Standard}
-    data-cy="standardButton"
+    data-cy={props["data-cy"] ?? "standardButton"}
     {...props}
   />
 );

--- a/packages/button/components/StandardDropdownButton.tsx
+++ b/packages/button/components/StandardDropdownButton.tsx
@@ -6,7 +6,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 const StandardDropdownButton = (props: ButtonProps) => (
   <StandardButton
     iconEnd={SystemIcons.TriangleDown}
-    data-cy="standardDropdownButton"
+    data-cy={props["data-cy"] ?? "standardDropdownButton"}
     {...props}
   />
 );

--- a/packages/button/components/SuccessButton.tsx
+++ b/packages/button/components/SuccessButton.tsx
@@ -9,7 +9,7 @@ import { LinkProps } from "../../link/types";
 const SuccessButton = (props: ButtonProps & LinkProps) => (
   <ButtonBase
     appearance={ButtonAppearances.Success}
-    data-cy="successButton"
+    data-cy={props["data-cy"] ?? "successButton"}
     {...props}
   />
 );

--- a/packages/button/components/SuccessDropdownButton.tsx
+++ b/packages/button/components/SuccessDropdownButton.tsx
@@ -6,7 +6,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 const SuccessDropdownButton = (props: ButtonProps) => (
   <SuccessButton
     iconEnd={SystemIcons.TriangleDown}
-    data-cy="successDropdownButton"
+    data-cy={props["data-cy"] ?? "successDropdownButton"}
     {...props}
   />
 );

--- a/packages/segmentedControl/components/SegmentedControl.tsx
+++ b/packages/segmentedControl/components/SegmentedControl.tsx
@@ -26,9 +26,9 @@ export interface SegmentedControlProps {
    */
   selectedSegment?: string;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
 }
 
 const SegmentedControl = (props: SegmentedControlProps) => {

--- a/packages/segmentedControl/components/SegmentedControlButton.tsx
+++ b/packages/segmentedControl/components/SegmentedControlButton.tsx
@@ -40,6 +40,10 @@ export interface SegmentedControlButtonProps {
    * Content that appears in a Tooltip when a users hovers the button
    */
   tooltipContent?: React.ReactNode;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
   children?: React.ReactNode;
 }
 
@@ -53,7 +57,8 @@ const SegmentedControlLabel = React.forwardRef(
       name,
       value,
       tooltipContent,
-      children
+      children,
+      "data-cy": dataCy = "segmentedControlButton"
     }: SegmentedControlButtonProps,
     ref
   ) => {
@@ -66,7 +71,7 @@ const SegmentedControlLabel = React.forwardRef(
           },
           className
         )}
-        data-cy="segmentedControlButton"
+        data-cy={dataCy}
         htmlFor={id}
         ref={ref as React.ForwardedRef<HTMLLabelElement>}
       >

--- a/packages/styleUtils/layout/stack/components/Stack.tsx
+++ b/packages/styleUtils/layout/stack/components/Stack.tsx
@@ -8,9 +8,9 @@ import { flex } from "../../../../shared/styles/styleUtils/layout/flexbox";
 export interface StackProps {
   className?: string;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   /**
    * The size of the space to apply between items. It can set 1 spacing size for all breakpoints, or it can be used to set different spacing values at different viewport width breakpoints.
    */

--- a/packages/styleUtils/typography/components/CaptionText.tsx
+++ b/packages/styleUtils/typography/components/CaptionText.tsx
@@ -12,9 +12,4 @@ const CaptionText = (props: SharedTextProps) => (
   />
 );
 
-CaptionText.defaultProps = {
-  align: "inherit",
-  tag: "p"
-};
-
 export default CaptionText;

--- a/packages/styleUtils/typography/components/SmallText.tsx
+++ b/packages/styleUtils/typography/components/SmallText.tsx
@@ -18,9 +18,9 @@ export interface SmallTextProps extends SharedTextProps {
    */
   weight: FontWeights;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
 }
 
 const SmallText = (props: SmallTextProps) => <Text size="s" {...props} />;
@@ -31,7 +31,7 @@ SmallText.defaultProps = {
   wrap: "wrap",
   weight: "normal",
   tag: "p",
-  ["data-cy"]: "smallText"
+  "data-cy": "smallText"
 };
 
 export default SmallText;

--- a/packages/styleUtils/typography/components/Text.tsx
+++ b/packages/styleUtils/typography/components/Text.tsx
@@ -23,15 +23,16 @@ const defaultTag = "p";
 
 const Text = (props: TextProps) => {
   const {
-    align,
+    align = "inherit",
     children,
-    tag,
-    wrap,
-    weight,
-    color,
-    size,
+    tag = defaultTag,
+    wrap = "wrap",
+    weight = "normal",
+    color = themeTextColorPrimary,
+    size = "m",
+
     className,
-    "data-cy": dataCy
+    "data-cy": dataCy = "text"
   } = props;
   const TextTag = tag || defaultTag;
   let title: string | undefined;

--- a/packages/styleUtils/typography/textTypes.ts
+++ b/packages/styleUtils/typography/textTypes.ts
@@ -15,9 +15,9 @@ export interface SharedTextProps {
    */
   tag?: keyof React.ReactHTML;
   /**
-   * human-readable selector used for writing tests
+   * Human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
   children: React.ReactNode;
 }
 

--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -81,13 +81,32 @@ export type TabDirections = "horiz" | "vert";
 export type TabDirection = BreakpointConfig<TabDirections>;
 export type TabSelected = string;
 export interface TabsProps {
+  /**
+   * Children should use the TabItem component
+   */
   children:
     | Array<React.ReactElement<TabItemProps>>
     | React.ReactElement<TabItemProps>;
+  /**
+   * The index number of the selected tab
+   */
   selectedIndex?: number;
+  /**
+   * The function called when tab items are selected
+   */
   onSelect?: (tabIndex: number) => void;
+  /**
+   * Controls the orientation
+   */
   direction?: TabDirection;
+  /**
+   * Allows custom styling
+   */
   className?: string;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const Tabs = ({
@@ -95,7 +114,8 @@ const Tabs = ({
   selectedIndex,
   onSelect,
   className,
-  direction = defaultTabDirection
+  direction = defaultTabDirection,
+  "data-cy": dataCy = "tabs"
 }: TabsProps) => {
   const { tabs, tabsContent } = (
     React.Children.toArray(children) as Array<React.ReactElement<TabItemProps>>
@@ -152,7 +172,7 @@ const Tabs = ({
       // empty arrow functions, so I disable this rule for this line
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       onSelect={onSelect ? onSelect : () => {}}
-      data-cy="tabs"
+      data-cy={dataCy}
       focusTabOnClick={false}
     >
       <TabList>{tabs}</TabList>

--- a/packages/textInput/components/TextInputWithBadges.tsx
+++ b/packages/textInput/components/TextInputWithBadges.tsx
@@ -87,7 +87,7 @@ const TextInputWithBadges = (props: TextInputWithBadgesProps) => {
       badges,
       onBadgeChange,
       downshiftReset,
-      addBadgeOnBlur,
+      addBadgeOnBlur = "true",
       badgeAppearance,
       ...inputProps
     } = baseProps as TextInputWithBadgesProps;

--- a/packages/toaster/components/Toast.tsx
+++ b/packages/toaster/components/Toast.tsx
@@ -32,6 +32,14 @@ export interface ToastProps {
   dismissToast?: (dismissedToastId: ToastId) => void;
   primaryAction?: React.ReactElement<HTMLElement>;
   secondaryAction?: React.ReactElement<HTMLElement>;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
 }
 
 const SuccessIcon = (
@@ -62,10 +70,11 @@ const Toast = ({
   secondaryAction,
   dismissToast,
   onDismiss,
-  id
+  id,
+  className,
+  "data-cy": dataCy = `toast toast.${appearance}`
 }: ToastProps) => {
   const isUrgentMessage = appearance === "danger" || appearance === "warning";
-  const dataCy = `toast toast.${appearance}`;
 
   const handleDismiss = e => {
     if (dismissToast) {
@@ -84,7 +93,8 @@ const Toast = ({
         padding("top", "xs"),
         padding("right", "xs"),
         padding("left", "xs"),
-        display("grid")
+        display("grid"),
+        className
       )}
       role={isUrgentMessage ? "alert" : "log"}
       aria-relevant="all"

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -12,13 +12,29 @@ const animationDuration = 300;
 type Toast = React.ReactElement<ToastProps>;
 
 interface ToasterProps {
+  /**
+   * Timer before toast is auto-dismissed
+   */
   dismissTime?: number;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
+  /**
+   * Allows custom styling
+   */
+  className?: string;
+  /**
+   * Children should use the Toast component
+   */
   children?: Toast | Toast[];
 }
 
 const Toaster = ({
   dismissTime = DEFAULT_DELAY_TIME,
-  children
+  children,
+  className,
+  "data-cy": dataCy = "toaster"
 }: ToasterProps) => {
   const timeouts = React.useRef<number[]>([]);
 
@@ -79,8 +95,13 @@ const Toaster = ({
 
   return (
     <div
-      className={cx(toaster, margin("all"), marginAt.medium("all", "l"))}
-      data-cy="toaster"
+      className={cx(
+        toaster,
+        margin("all"),
+        marginAt.medium("all", "l"),
+        className
+      )}
+      data-cy={dataCy}
     >
       <ol
         onMouseEnter={clearTimeouts}

--- a/packages/toggleInput/components/ToggleInput.tsx
+++ b/packages/toggleInput/components/ToggleInput.tsx
@@ -87,16 +87,16 @@ interface LocalToggleInputProps extends ToggleInputProps {
 const ToggleInput = React.forwardRef<HTMLInputElement, LocalToggleInputProps>(
   (props, forwardedRef) => {
     const {
-      appearance,
+      appearance = InputAppearance.Standard,
       children,
       className,
       disabled,
       hintContent,
       id = nextId("toggleInput-"),
       inputLabel,
-      showInputLabel,
-      vertAlign,
-      inputType,
+      showInputLabel = true,
+      vertAlign = "center",
+      inputType = "checkbox",
       checked,
       value,
       errors,
@@ -215,12 +215,5 @@ const ToggleInput = React.forwardRef<HTMLInputElement, LocalToggleInputProps>(
     );
   }
 );
-
-ToggleInput.defaultProps = {
-  appearance: InputAppearance.Standard,
-  showInputLabel: true,
-  vertAlign: "center",
-  inputType: "checkbox"
-};
 
 export default ToggleInput;

--- a/packages/toggleWrapper/components/ToggleWrapper.tsx
+++ b/packages/toggleWrapper/components/ToggleWrapper.tsx
@@ -27,7 +27,7 @@ export interface ToggleWrapperProps extends React.HTMLProps<HTMLInputElement> {
   /**
    * human-readable selector used for writing tests
    */
-  ["data-cy"]?: string;
+  "data-cy"?: string;
 }
 
 interface ToggleWrapperWithRenderProps
@@ -89,11 +89,6 @@ const ToggleWrapper = ({
     </label>
     /* eslint-enable jsx-a11y/role-supports-aria-props */
   );
-};
-
-ToggleWrapper.defaultProps = {
-  type: "checkbox",
-  value: ""
 };
 
 export default React.memo(ToggleWrapper);

--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -97,7 +97,7 @@ const Tooltip = ({
     onMouseLeave: handleClose,
     onFocus: handleOpen,
     onBlur: handleClose,
-    ["data-cy"]: "tooltip",
+    "data-cy": "tooltip",
     ref: setTriggerNode
   };
 

--- a/packages/tooltip/components/TooltipContent.tsx
+++ b/packages/tooltip/components/TooltipContent.tsx
@@ -7,8 +7,18 @@ import { BaseTooltipProps } from "./Tooltip";
 import { Direction } from "../../dropdownable/components/Dropdownable";
 
 export interface TooltipContentProps extends BaseTooltipProps {
+  /**
+   * Set a direction for the tooltip to open toward
+   */
   direction?: Direction;
+  /**
+   * Controls if opened by default
+   */
   isOpen: boolean;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const TooltipContent = ({
@@ -17,7 +27,8 @@ const TooltipContent = ({
   id,
   maxWidth,
   minWidth,
-  isOpen
+  isOpen,
+  "data-cy": dataCy = "tooltipContent"
 }: TooltipContentProps) => {
   return (
     <>
@@ -36,7 +47,7 @@ const TooltipContent = ({
           minWidth,
           maxWidth: maxWidth || undefined
         }}
-        data-cy="tooltipContent"
+        data-cy={dataCy}
       >
         {children}
       </div>

--- a/packages/typeahead/components/Typeahead.tsx
+++ b/packages/typeahead/components/Typeahead.tsx
@@ -62,6 +62,10 @@ export interface TypeaheadProps {
    * Whether the dropdown node should be portalled to document.body, or open in it's parent DOM node
    */
   disablePortal?: boolean;
+  /**
+   * Human-readable selector used for writing tests
+   */
+  "data-cy"?: string;
 }
 
 const defaultItemToString = item => (item ? item.value : "");
@@ -86,6 +90,7 @@ const Typeahead = ({
   multiSelect,
   keepOpenOnSelect,
   resetInputOnSelect,
+  "data-cy": dataCy = "typeahead",
   onSelect
 }: TypeaheadProps) => {
   const { value, ...textFieldProps } = textField.props;
@@ -192,7 +197,7 @@ const Typeahead = ({
   }
 
   return (
-    <div ref={containerRef} className={className} data-cy="typeahead">
+    <div ref={containerRef} className={className} data-cy={dataCy}>
       <Downshift
         itemToString={defaultItemToString}
         selectedItem={selectedItems}


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Throughout these changes I am looking to achieve the following:
- Add `data-cy` attributes that we will be able to pass in custom values. Improving DX with our components + Cypress testing. I have opted for consistent use of `"data-cy"` instead of `["data-cy"]` as the [] is unnecessary. 
- Add `className` to an outermost container on components, that we can use for style overrides in the future.
- Consistency in the casing of prop definitions, as this displays to the Storybook UI in the Docs tab.
- Remove unnecessary `defaultProps` and opt for default values set during prop destructuring. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
