### PR TITLE
fix: set ui team as default code reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # Reference: https://help.github.com/en/articles/about-code-owners
-
 # Order is important: later rules override preceding rules
-
-- @d2iq/ui-team
+* @d2iq/ui-team


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

The file got auto-formatted at some point and changed the `*` to a `-` thinking it was a bullet point. The `*` is necessary and represents all the files present in the repo.
This will allow the d2iq/ui-team to be set as the default code reviewers on PRs.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
I don't think we can fully test this until after it is merged in.

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
