### PR TITLE
feat: list tag prop is optional

### DIFF
--- a/packages/list/components/List.tsx
+++ b/packages/list/components/List.tsx
@@ -10,7 +10,7 @@ export interface SharedListProps {
   /**
    * Set to an ordered list `ol` or the defaulted unordered list `ul`
    */
-  tag: "ul" | "ol";
+  tag?: "ul" | "ol";
   /**
    * Human-readable selector used for writing tests
    */


### PR DESCRIPTION
The tag property has always had a fallback/default value of "ul". Because of this, the property should be optional to set. Moving the from defaultProps to using fallbacks triggered this requirement.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
