### PR TITLE
fix: height of segmentedcontrol

### DIFF
--- a/packages/segmentedControl/style.ts
+++ b/packages/segmentedControl/style.ts
@@ -49,6 +49,7 @@ export const segmentedControlButton = css`
 
 export const segmentedControlButtonInner = css`
   padding: ${buttonPadding.vert} ${buttonPadding.horiz};
+  line-height: normal;
 `;
 
 export const segmentedControlButtonActive = css`

--- a/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`SegmentedControl renders default 1`] = `
 
 .emotion-3 {
   padding: 10px 18px;
+  line-height: normal;
 }
 
 <div
@@ -188,6 +189,7 @@ exports[`SegmentedControl renders with selected 1`] = `
 
 .emotion-3 {
   padding: 10px 18px;
+  line-height: normal;
 }
 
 .emotion-4 {


### PR DESCRIPTION
The height of the SegmentedControl is not consistent with other elements. It should align with other components such as buttons, and form elements.

Closes D2IQ-95243

<!-- PR Checklist -->

# Description

The height of the SegementedControl component is slightly larger than other components. 
There are some extra height calculations happening in this component due to `line-height` that is just enough to set it off by a few pixels.
This will help the component to look in line with other form elements that we'd like to place it next to. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs
If you'd like to double-check the work, you can inspect the SegmentedControl and the height should be around 36px instead of 39. 

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

**Here is a side-by-side of a before and after.**

<img width="1356" alt="Screenshot 2023-02-17 at 10 13 08 AM" src="https://user-images.githubusercontent.com/34781875/219707577-7fcff389-7259-487e-b548-4c1c732dccc1.png">


**Before**
<img width="520" alt="Screenshot 2023-02-17 at 10 25 13 AM" src="https://user-images.githubusercontent.com/34781875/219709039-28f24ad0-f603-4b9b-a381-c1f75369e8e6.png">


**After**
<img width="571" alt="Screenshot 2023-02-17 at 10 23 29 AM" src="https://user-images.githubusercontent.com/34781875/219708667-4a437976-3963-4a28-82be-6d2e084f52bc.png">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [x] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
