### PR TITLE
fix: fixed tag default prop for spacing box

### DIFF
--- a/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
@@ -35,12 +35,12 @@ exports[`MessagePanel appearance='error' 1`] = `
                 xlink:href="#system-circle-close"
               />
             </svg>
-            <div
+            <span
               class="css-m1scup"
               data-cy="spacingBox"
             >
               Heading
-            </div>
+            </span>
           </h2>
         </div>
         <div

--- a/packages/styleUtils/modifiers/components/SpacingBox.tsx
+++ b/packages/styleUtils/modifiers/components/SpacingBox.tsx
@@ -46,7 +46,12 @@ const SpacingBox = (props: SpacingBoxProps) => {
     : padding(side, spacingSize);
 
   return (
-    <Box className={cx(className, paddingStyles)} data-cy={dataCy} {...other} />
+    <Box
+      className={cx(className, paddingStyles)}
+      data-cy={dataCy}
+      tag={tag}
+      {...other}
+    />
   );
 };
 


### PR DESCRIPTION

# Description
Looks like when we changed default props tag wasn't passed in properly.

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
