### PR TITLE
fix: fix disabled not working on select input

### DIFF
--- a/packages/selectInput/components/SelectInput.tsx
+++ b/packages/selectInput/components/SelectInput.tsx
@@ -154,6 +154,7 @@ const SelectInput = ({
               onFocus={handleFocus}
               onBlur={handleBlur}
               data-cy={selectDataCy}
+              disabled={disabled}
               {...other}
             >
               {options.map((option, key) => (

--- a/packages/selectInput/tests/SelectInput.test.tsx
+++ b/packages/selectInput/tests/SelectInput.test.tsx
@@ -63,7 +63,7 @@ describe("SelectInput", () => {
   });
 
   it("renders disabled", () => {
-    const { asFragment } = render(
+    const { asFragment, getByRole } = render(
       <SelectInput
         options={defaultOptions}
         id="layers"
@@ -72,6 +72,8 @@ describe("SelectInput", () => {
       />
     );
     expect(asFragment()).toMatchSnapshot();
+    const selectElement = getByRole("combobox") as HTMLSelectElement;
+    expect(selectElement.disabled).toBe(true);
   });
 
   it("renders with hidden label", () => {

--- a/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
+++ b/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
@@ -810,6 +810,7 @@ exports[`SelectInput renders disabled 1`] = `
         aria-invalid="false"
         class="emotion-2"
         data-cy="selectInput-select selectInput-select.standard"
+        disabled=""
         id="layers"
       >
         <option


### PR DESCRIPTION

# Description

This adds the disabled prop to `SelectInput`. This is not working before. I also added something to the test to make sure it is disabled.

## Which issue(s) does this PR relate to?

 - https://jira.d2iq.com/browse/D2IQ-96288

## Testing

Add a disabled tag to a SelectInput and make sure it works.

## Checklist

- [x] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
