### PR TITLE
refactor: TextInputWithButtons story

### DIFF
--- a/packages/textInput/components/TextInputWithButtons.tsx
+++ b/packages/textInput/components/TextInputWithButtons.tsx
@@ -87,7 +87,7 @@ const TextInputWithButtons = ({
         hintContent={props.hintContent}
       >
         {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
-          <React.Fragment>
+          <>
             <div
               className={cx(
                 flex(),
@@ -103,6 +103,7 @@ const TextInputWithButtons = ({
                   showInputLabel,
                   ...props
                 },
+                // the icon takes on the color of the input appearance
                 getInputAppearance()
               )}
               {getInputElement(
@@ -122,7 +123,7 @@ const TextInputWithButtons = ({
             </div>
             {getHintContent}
             {getValidationErrors}
-          </React.Fragment>
+          </>
         )}
       </FormFieldWrapper>
     );

--- a/packages/textInput/stories/TextInputWithButtons.stories.tsx
+++ b/packages/textInput/stories/TextInputWithButtons.stories.tsx
@@ -5,6 +5,7 @@ import { InputStoryWrapper } from "../../../decorators/inputStoryWrapper";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { TextInputButton } from "../../textInputButton";
 import { Icon } from "../../icon";
+import { themeBrandPrimary } from "../../design-tokens/build/js/designTokens";
 
 const btnClickFn = () => {
   alert("button one clicked");
@@ -13,10 +14,7 @@ const btnClickFn = () => {
 export default {
   title: "Forms/TextInputWithButtons",
   decorators: [Story => <InputStoryWrapper>{Story()}</InputStoryWrapper>],
-  component: TextInputWithButtons,
-  args: {
-    appearance: "standard"
-  }
+  component: TextInputWithButtons
 };
 
 const Template: Story = args => (
@@ -36,21 +34,19 @@ const Template: Story = args => (
 );
 
 export const Default = Template.bind({});
+Default.args = {};
 
-export const WithCustomIcons = args => (
-  <TextInputWithButtons
-    id="withIcon.colored"
-    inputLabel="With colored icon"
-    iconStart={<Icon shape={SystemIcons.Search} />}
-    buttons={[
-      <TextInputButton
-        key={0}
-        color="red"
-        shape={SystemIcons.Close}
-        onClick={btnClickFn}
-        aria-label="Clear input"
-      />
-    ]}
-    {...args}
-  />
-);
+export const WithCustomIcons = Template.bind({});
+WithCustomIcons.args = {
+  inputLabel: "With colored icon",
+  iconStart: <Icon shape={SystemIcons.Search} color={themeBrandPrimary} />,
+  buttons: [
+    <TextInputButton
+      key={0}
+      color="red"
+      shape={SystemIcons.Close}
+      onClick={btnClickFn}
+      aria-label="Clear input"
+    />
+  ]
+};


### PR DESCRIPTION
<!-- PR Checklist -->

# Description
This fixes the story controls so that it doesn't freeze when you change the appearance.

I've refactored this again as I've discovered the intended behavior here is that the  `iconStart` will take on the color of the input. However, the button can take on its own color. I've added a comment to clarify this for the future. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
