### PR TITLE
feat: updated bg colors for header and sidebar

### DIFF
--- a/packages/appChrome/components/HeaderBar.tsx
+++ b/packages/appChrome/components/HeaderBar.tsx
@@ -4,10 +4,9 @@ import { flex } from "../../shared/styles/styleUtils";
 import { ThemeProvider, useTheme } from "@emotion/react";
 import { headerBar } from "../style";
 import { AppChromeTheme } from "../types";
-import { getCSSVarValue } from "../../utilities";
-import { themeBgPrimary } from "../../design-tokens/build/js/designTokens";
+import { greyLightLighten4 } from "../../design-tokens/build/js/designTokens";
 
-export const defaultBgColor = getCSSVarValue(themeBgPrimary);
+export const defaultBgColor = greyLightLighten4;
 export const defaultHeaderPaddingHor = "none";
 export const defaultHeaderPaddingVert = "none";
 
@@ -32,7 +31,7 @@ const StyledHeader = ({ children }: HeaderProps) => {
 const Header = ({ bgColor, children }: HeaderProps) => {
   const adjustedTheme = ancestorTheme => {
     return {
-      headerBackgroundColor: bgColor || getCSSVarValue(themeBgPrimary),
+      headerBackgroundColor: bgColor || greyLightLighten4,
       ...ancestorTheme
     };
   };

--- a/packages/appChrome/components/Sidebar.tsx
+++ b/packages/appChrome/components/Sidebar.tsx
@@ -2,8 +2,10 @@ import * as React from "react";
 import { cx } from "@emotion/css";
 import { ThemeProvider, useTheme } from "@emotion/react";
 import { sidebar, sidebarAnimator, sidebarContainer } from "../style";
-import { themeBgDisabled } from "../../design-tokens/build/js/designTokens";
-import getCSSVarValue from "../../utilities/getCSSVarValue";
+import {
+  greyLightLighten1,
+  greyLightLighten4
+} from "../../design-tokens/build/js/designTokens";
 import { getResponsiveStyle } from "../../shared/styles/styleUtils";
 import { AppChromeTheme } from "../types";
 export interface SidebarProps {
@@ -85,10 +87,9 @@ const Sidebar = ({
 
   const adjustedTheme = ancestorTheme => {
     return {
-      sidebarBackgroundColor: bgColor || getCSSVarValue(themeBgDisabled),
-      // TODO update these with design tokens
-      itemActiveBackgroundColor: activeColor || "#D0D4D7",
-      itemHoverBackgroundColor: hoverColor || "#DDDFE2",
+      sidebarBackgroundColor: bgColor || greyLightLighten4,
+      itemActiveBackgroundColor: activeColor || greyLightLighten1,
+      itemHoverBackgroundColor: hoverColor || greyLightLighten1,
       sidebarWidth: defaultSidebarWidths,
       ...ancestorTheme
     };

--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -10,7 +10,7 @@ import {
   themeBgPrimary
 } from "../design-tokens/build/js/designTokens";
 import { padding, tintContent } from "../shared/styles/styleUtils";
-import { pickHoverBg, pickReadableTextColor } from "../shared/styles/color";
+import { pickHoverBg, getTextColor } from "../shared/styles/color";
 import getCSSVarValue from "../utilities/getCSSVarValue";
 import { AppChromeTheme } from "./types";
 import {
@@ -45,7 +45,7 @@ export const appWrapper = css`
 
 export const headerBar = (theme: AppChromeTheme) => {
   const bgColor = theme.headerBackgroundColor || getCSSVarValue(themeBgPrimary);
-  const textColor = pickReadableTextColor(
+  const textColor = getTextColor(
     bgColor,
     getCSSVarValue(themeTextColorPrimary),
     getCSSVarValue(themeTextColorPrimaryInverted)
@@ -75,7 +75,7 @@ export const sidebar = css`
 export const sidebarContainer = (theme: AppChromeTheme, isOpen?: boolean) => {
   const bgColor =
     theme.sidebarBackgroundColor || getCSSVarValue(themeBgDisabled);
-  const textColor = pickReadableTextColor(
+  const textColor = getTextColor(
     bgColor,
     getCSSVarValue(themeTextColorPrimary),
     getCSSVarValue(themeTextColorPrimaryInverted)
@@ -84,7 +84,7 @@ export const sidebarContainer = (theme: AppChromeTheme, isOpen?: boolean) => {
   return css`
     background-color: ${bgColor};
     transform: ${`translateX(${isOpen ? 0 : "-100%"})`};
-    ${tintContent(textColor)};
+    color: ${textColor};
   `;
 };
 
@@ -135,7 +135,7 @@ export const sidebarNavItem = (
   return css`
     background-color: ${itemBgColor};
     color: ${isActive
-      ? pickReadableTextColor(
+      ? getTextColor(
           itemBgColor,
           getCSSVarValue(themeTextColorPrimary),
           getCSSVarValue(themeTextColorPrimaryInverted)

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -3,13 +3,12 @@
 exports[`Sidebar SidebarItem renders 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-color: #E8EAED;
+  background-color: #F0F1F3;
   -webkit-transform: translateX(0);
   -moz-transform: translateX(0);
   -ms-transform: translateX(0);
   transform: translateX(0);
   color: #1B2029;
-  fill: #1B2029;
   height: 100%;
   overflow-x: hidden;
   -webkit-transition: width 150ms ease-in-out,-webkit-transform 150ms ease-in-out;
@@ -45,7 +44,7 @@ exports[`Sidebar SidebarItem renders 1`] = `
 }
 
 .emotion-2 {
-  background-color: #E8EAED;
+  background-color: #F0F1F3;
   cursor: pointer;
   opacity: 1;
   text-transform: capitalize;
@@ -59,7 +58,7 @@ exports[`Sidebar SidebarItem renders 1`] = `
 .emotion-2:hover,
 .emotion-2:focus,
 .emotion-2:focus-within {
-  background-color: #DDDFE2;
+  background-color: #DDE0E4;
 }
 
 .emotion-2:hover,
@@ -351,13 +350,12 @@ exports[`Sidebar SidebarSubMenuItem renders 1`] = `
 exports[`Sidebar renders 1`] = `
 <DocumentFragment>
   .emotion-0 {
-  background-color: #E8EAED;
+  background-color: #F0F1F3;
   -webkit-transform: translateX(0);
   -moz-transform: translateX(0);
   -ms-transform: translateX(0);
   transform: translateX(0);
   color: #1B2029;
-  fill: #1B2029;
   height: 100%;
   overflow-x: hidden;
   -webkit-transition: width 150ms ease-in-out,-webkit-transform 150ms ease-in-out;


### PR DESCRIPTION
Updated theming for the AppChrome component.
Introduced a new function to set text color based on background color.

BREAKING CHANGE:
This changes the default background color for the AppChrome header and sidebar.

Closes D2IQ-96041

<!-- PR Checklist -->

# Description

This is a change requested by the product design team. 
We'd like to update the background color for the header and sidebar to use the same grey color. The design token we'd like to use is greyLightLighten4. The design token we will use for the active state of the sidebar is greyLightLighten1.

I brought in the function `getTextColor` that I recently created and used in kommander-ui. 
In a separate follow-up to this addition, I will update components that use `pickReadableTextColor` to move over to using `getTextColor`. I made a few additions to getTextColor so that it can take in custom colors for the light and dark text colors and calculate based on those.
While creating the background color updates, I had to add `getTextColor` because I noticed some really odd behavior with the other function. I passed in a light grey background color and the text would appear as a light color. Upon further review, I found a code comment about this around the other function:
```
// Normally this function would compare the contrast
// between the baseTextOption and invertedTextOption,
// but that forces text to be black on our success buttons.
//
// Checking with brightness still returns us the most readable
// option on the background color, but will let the success
// button have white text.
//
// The design team should try a different success color
// to improve legibility and accessibility.
```
I followed up with the design team to advise them about the color contrast issues with our success/green color. 
As you can see this function had to be used as a workaround to force light text on components such as the SuccessButton. This is an a11y issue and for that reason, we can deprecate pickReadableTextColor and opt for the new function moving forward. I will create a new story for all of this refactoring.


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?
https://d2iq.atlassian.net/browse/D2IQ-96041

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
I tested this out with npm link in kommander-ui. 
So that is an option. 
You can also mess around with some different colors through the AppChrome stories.


<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

Side-by-side comparison.
(left = after, right = before)
<img width="1779" alt="Screenshot 2023-05-08 at 1 52 51 PM" src="https://user-images.githubusercontent.com/34781875/236908032-1e1a26b1-558c-4c0c-a4f3-9282a9371e02.png">



Tested with npm link:
<img width="1837" alt="Screenshot 2023-05-08 at 1 13 56 PM" src="https://user-images.githubusercontent.com/34781875/236907411-5be38dbd-9ebe-435b-a968-f7a3349aa1a7.png">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
