### PR TITLE
fix: slideToggle console errors

### DIFF
--- a/packages/slideToggle/components/SlideToggle.tsx
+++ b/packages/slideToggle/components/SlideToggle.tsx
@@ -36,15 +36,15 @@ export interface SlideToggleProps extends React.HTMLProps<HTMLInputElement> {
    */
   appearance?: InputAppearance;
   /**
-   * Whether or not the input is checked
+   * Whether or not the input is checked.
    */
   checked?: boolean;
   /**
-   * Unique identifier used for the input element
+   * Unique identifier used for the input element.
    */
   id?: string;
   /**
-   * The text or node content that appears next to the input
+   * The text or node content that appears next to the input.
    */
   inputLabel: React.ReactNode | string;
   /**
@@ -56,7 +56,7 @@ export interface SlideToggleProps extends React.HTMLProps<HTMLInputElement> {
    */
   value?: string;
   /**
-   * How the text content vertically aligns with the input
+   * How the text content vertically aligns with the input.
    */
   vertAlign?: "center" | "top";
   /**
@@ -87,7 +87,9 @@ const SlideToggle = (props: React.PropsWithRef<SlideToggleProps>) => {
     onFocus,
     ...other
   } = props;
+
   const inputType = "SlideToggle";
+
   const inputDataCy = [
     `${inputType}-input`,
     ...(checked ? [`${inputType}-input.checked`] : []),
@@ -95,6 +97,7 @@ const SlideToggle = (props: React.PropsWithRef<SlideToggleProps>) => {
       ? [`${inputType}-input.${appearance}`]
       : [])
   ].join(" ");
+
   const parentDataCy = [
     `${inputType}`,
     ...(checked ? [`${inputType}.checked`] : []),
@@ -102,7 +105,9 @@ const SlideToggle = (props: React.PropsWithRef<SlideToggleProps>) => {
       ? [`${inputType}.${appearance}`]
       : [])
   ].join(" ");
+
   const [hasFocus, setHasFocus] = React.useState<boolean>(false);
+
   const handleFocus = e => {
     setHasFocus(true);
 
@@ -131,14 +136,13 @@ const SlideToggle = (props: React.PropsWithRef<SlideToggleProps>) => {
             <div className={cx(flexItem("shrink"), display("inherit"))}>
               <>
                 <div className={cx(toggleContainer)}>
-                  {/* eslint-disable jsx-a11y/role-has-required-aria-props */}
                   <input
                     type={inputType}
                     id={id}
                     className={visuallyHidden}
-                    checked={checked}
+                    defaultChecked={checked}
                     disabled={disabled}
-                    value={value}
+                    defaultValue={value}
                     aria-invalid={!isValid}
                     aria-describedby={describedByIds}
                     onFocus={handleFocus}


### PR DESCRIPTION
Closes D2IQ-98165

<!-- PR Checklist -->

# Description

I discovered console errors around the SlideToggle component. One around the value and one around checked. The error suggests the use of defaultValue and defaultChecked. Using these resolved the error. 

```You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.```

<img width="624" alt="Screenshot 2023-07-07 at 1 53 05 PM (1)" src="https://github.com/d2iq/ui-kit/assets/34781875/83854605-7853-4459-81ea-0c7f9c11e94f">


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
 - https://jira.d2iq.com/browse/D2IQ-98165

## Testing
View the console while looking at the SlideToggle story. 

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots'
Before
<img width="1662" alt="Screenshot 2023-07-11 at 9 43 52 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/7d98c5d1-357b-4710-8cfc-879fe1196294">


After
<img width="1673" alt="Screenshot 2023-07-11 at 9 41 46 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/b2d1bfeb-e996-40d5-a021-b72d8bfe18df">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
