### PR TITLE
fix: recalibrate getTextColor function

### DIFF
--- a/packages/shared/styles/color.ts
+++ b/packages/shared/styles/color.ts
@@ -81,38 +81,48 @@ export const getTextColor = (
   darkTextColor,
   lightTextColor
 ): string => {
-  // Convert color from hex to RGB.
-  const getRGB = (c: string | number): number => {
-    return parseInt(c as string, 16) || (c as number);
-  };
-
-  // Convert to sRGB and apply gamma correction.
-  const getsRGB = (c: string): number => {
-    const rgb = getRGB(c) / 255;
-    return rgb <= 0.03928 ? rgb / 12.92 : Math.pow((rgb + 0.055) / 1.055, 2.4);
-  };
-
-  // Calculate relative luminance.
-  const getLuminance = (hexColor: string): number => {
-    return (
-      0.2126 * getsRGB(hexColor.slice(1, 3)) +
-      0.7152 * getsRGB(hexColor.slice(3, 5)) +
-      0.0722 * getsRGB(hexColor.slice(5, 7))
-    );
-  };
-
-  // Use relative luminance to compare color contrast.
   const getContrast = (f: string, b: string): number => {
+    // Use relative luminance to compare color contrast.
+    const getLuminance = (hexColor: string): number => {
+      // Convert to sRGB and apply gamma correction.
+      const getRGB = (c: string | number): number =>
+        parseInt(c as string, 16) || (c as number);
+      const getsRGB = (c: string): number => {
+        const rgb = getRGB(c) / 255;
+        return rgb <= 0.03928
+          ? rgb / 12.92
+          : Math.pow((rgb + 0.055) / 1.055, 2.4);
+      };
+
+      return (
+        0.2126 * getsRGB(hexColor.slice(1, 3)) +
+        0.7152 * getsRGB(hexColor.slice(3, 5)) +
+        0.0722 * getsRGB(hexColor.slice(5, 7))
+      );
+    };
+
     const L1 = getLuminance(f);
     const L2 = getLuminance(b);
-    // Ratio formula is defined by WCAG guidelines
     return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
   };
 
-  const LIGHT_COLOR = getContrast(bgColor, lightTextColor);
-  const DARK_COLOR = getContrast(bgColor, darkTextColor);
+  // WCAG 2.2 color contrast standard for normal text.
+  const MIN_NORMAL_CONTRAST = 4.5;
+
+  const contrastWithDarkText = getContrast(bgColor, darkTextColor);
+  const contrastWithLightText = getContrast(bgColor, lightTextColor);
+
+  if (
+    contrastWithLightText >= MIN_NORMAL_CONTRAST &&
+    contrastWithDarkText < MIN_NORMAL_CONTRAST
+  ) {
+    return lightTextColor;
+  }
+
   // Determine which color has the highest contrast ratio and return that color.
-  return LIGHT_COLOR > DARK_COLOR ? lightTextColor : darkTextColor;
+  return contrastWithDarkText > MIN_NORMAL_CONTRAST
+    ? darkTextColor
+    : lightTextColor;
 };
 
 // Assumes we always want our default hover colors to be lower


### PR DESCRIPTION
Ensure that getTextColor is choosing colors with better contrast.

<!-- PR Checklist -->

# Description

QA noticed that using this color #005E70 for a background color opted for a dark text color. This does not pass WCAG 2.0 AA compliance of a 4.5:1 contrast ratio for normal text. Therefore the text was hard to read on the background color. 
I've adjusted and tested this function so that it will perform better and choose the text color with a higher color contrast.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
The best way to test this would be to bring it in downstream. So either copy/paste the function over in the code or try to use npm link. 
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs
This function is pretty complex 😅 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
