### PR TITLE
fix: set z-index for center dialog wrapper

### DIFF
--- a/packages/modal/style.ts
+++ b/packages/modal/style.ts
@@ -49,6 +49,7 @@ export const centerDialogWrapper = css`
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: ${zIndexModal};
 `;
 
 export const modal = css`


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The change in #982 doesn't work as expected for the original issue.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

* Install the newest (15.0.0) ui-kit version
* Go to the kommander-default-workspace
* Disable cert-manager
* Edit traefik (change configuration) and hit save to see the modal
* see the editor still overalying the modal

Apply ui-kit changes from this PR like you usually do (npm link or copying files) and rerun the testing step, except the first one to install ui-kit. In the last step you should see the modal on top of the editor.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

before 
<img width="1046" alt="Screenshot 2023-07-27 at 10 54 44" src="https://github.com/d2iq/ui-kit/assets/12071529/5220d4bf-ace5-47ae-ae74-0848e415a838">

after

<img width="1792" alt="Screenshot 2023-07-27 at 10 56 49" src="https://github.com/d2iq/ui-kit/assets/12071529/683f3eb8-a36d-4924-8bd5-73bf4d3187fd">


## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
