### PR TITLE
docs: update to use search icon by default

### DIFF
--- a/packages/textInput/stories/TextInputWithIcon.stories.tsx
+++ b/packages/textInput/stories/TextInputWithIcon.stories.tsx
@@ -37,16 +37,14 @@ export default {
     }
   },
   args: {
-    appearance: "standard",
-    inputLabel: "Default Input Label",
-    iconStart: SystemIcons.TriangleDown
+    inputLabel: "Default Input Label"
   }
 } as Meta;
 
 const Template: StoryFn = args => (
   <TextInputWithIcon
     id="standard.input"
-    iconStart={SystemIcons.TriangleDown}
+    iconStart={SystemIcons.Search}
     {...args}
   />
 );


### PR DESCRIPTION
Updating this component story to be a better,
example of how this component may be used.
The search magnifying glass is a good example.

<!-- PR Checklist -->

# Description

I'd like to change the default icon here to something that is a bit more exemplarily on how you'd normally use this component. 

We had this TriangleDown icon set here as the default.
<img width="333" alt="Screenshot 2023-09-21 at 3 08 28 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/ecbebefa-c243-4d9b-9007-0992da9c83c6">
I think this adds confusion as it makes it seem like it's a dropdown. 

These text inputs can often be used for search so this is a better example use case. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
View the TextInputWithIcons story.
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
<img width="1541" alt="Screenshot 2023-09-21 at 1 37 11 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/b5dcb3b3-1523-4a78-b9e3-c49877db2796">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
