### PR TITLE
docs: storybook theming values

### DIFF
--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,40 +1,55 @@
 import { create } from "@storybook/theming/create";
 import logo from "./static/logo.png";
+import { getCSSVarValue } from "../packages/shared/styles/styleUtils/typography/color";
+import {
+  borderRadiusDefault,
+  fontFamilyMonospace,
+  fontFamilySansSerif,
+  themeBgPrimary,
+  themeBorder,
+  themeBrandPrimary,
+  themeBgSecondary,
+  themeTextColorDisabled,
+  themeTextColorPrimary,
+  themeTextColorPrimaryInverted
+} from "../packages/design-tokens/build/js/designTokens";
 
 export default create({
   base: "light",
 
-  colorPrimary: "#FF00D7",
-  colorSecondary: "#7D58FF",
-
-  // UI
-  appBg: "#FFF",
-  appContentBg: "#F7F8F9",
-  appBorderColor: "#DADDE2",
-  appBorderRadius: 6,
-
-  // Typography
-  fontBase:
-    "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica', 'Arial', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
-  fontCode:
-    "'Menlo', 'Bitstream Vera Sans Mono', 'DejaVu Sans Mono', 'Monaco', 'Consolas', monospace",
-
-  // Text colors
-  textColor: "#1B2029",
-  textInverseColor: "#FFF",
-
-  // Toolbar default and active colors
-  barTextColor: "#1B2029",
-  barSelectedColor: "#7D58FF",
-  barBg: "#FFF",
-
-  // Form colors
-  inputBg: "#FFF",
-  inputBorder: "#DADDE2",
-  inputTextColor: "#1B2029",
-  inputBorderRadius: 6,
-
+  // Brand
   brandTitle: "D2iQ UI Kit",
   brandUrl: "./",
-  brandImage: logo
+  brandImage: logo,
+  brandTarget: "_self",
+
+  // Typography
+  fontBase: fontFamilySansSerif,
+  fontCode: fontFamilyMonospace,
+
+  // Main Colors
+  colorPrimary: getCSSVarValue(themeBrandPrimary),
+  colorSecondary: getCSSVarValue(themeBrandPrimary),
+
+  // Text Colors
+  textColor: getCSSVarValue(themeTextColorPrimary),
+  textInverseColor: getCSSVarValue(themeTextColorPrimaryInverted),
+  textMutedColor: getCSSVarValue(themeTextColorDisabled),
+
+  // App Styles
+  appBg: getCSSVarValue(themeBgPrimary),
+  appContentBg: getCSSVarValue(themeBgSecondary),
+  appBorderColor: getCSSVarValue(themeBorder),
+  appBorderRadius: borderRadiusDefault,
+
+  // Toolbar Colors
+  barTextColor: getCSSVarValue(themeTextColorPrimary),
+  barSelectedColor: getCSSVarValue(themeBrandPrimary),
+  barBg: getCSSVarValue(themeBgPrimary),
+
+  // Form Styles
+  inputBg: getCSSVarValue(themeBgPrimary),
+  inputBorder: getCSSVarValue(themeBorder),
+  inputTextColor: getCSSVarValue(themeTextColorPrimary),
+  inputBorderRadius: borderRadiusDefault
 });


### PR DESCRIPTION
Updated storybook theming to use design token values.

<!-- PR Checklist -->

# Description
With this work I reviewed if there were any changes to how storybook handles theming overrides with v7.
It was all about the same, though I did find some new values for example `brandTarget: "_self",` which is applicable for us because when clicking the logo it takes you to the home page. 
The "_self" value for the target attribute indicates that the linked content should be displayed in the same browsing context or the same window/tab where the link was clicked.

We need to use the getCSSVarValue function here because of how our theming DS are formatted - `export const themeBrandPrimary: string = "var(--themeBrandPrimary, #7D58FF)";` 
Otherwise you'll see this error `Uncaught Error: Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.`

This updates our theme file to use our theme design token values. 
Theming should change much here at all. It's mainly to address using all values from our DS for consistent theming.
If we make an update to a main color it will be reflected here in the storybook too. 

I also found an opportunity here to add some better organization to this file. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Start up storybook and scope out some stories. 
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
Before
<img width="1209" alt="Screenshot 2023-09-25 at 10 08 00 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/4c4e29b4-c265-49b2-a86d-dd9af80110ef">


After
<img width="1213" alt="Screenshot 2023-09-25 at 10 08 40 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/98c66f08-102f-467f-864b-fffec659f405">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
