### PR TITLE
docs: access to all product icons for breadcrumb

### DIFF
--- a/packages/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -5,17 +5,25 @@ import { action } from "@storybook/addon-actions";
 import { ProductIcons } from "../../icons/dist/product-icons-enum";
 import { BreadcrumbProps } from "../components/Breadcrumb";
 
+// Filter out "Inverse" product icons for this story
+const filteredProductIcons = Object.keys(ProductIcons)
+  .filter(key => !key.includes("Inverse"))
+  .reduce((obj, key) => {
+    obj[key] = ProductIcons[key];
+    return obj;
+  }, {});
+
 export default {
   title: "Navigation/Breadcrumb",
   component: BreadcrumbItem,
   subcomponents: { Breadcrumb },
   argTypes: {
     icon: {
-      options: [ProductIcons.Gear, ProductIcons.Cluster, ProductIcons.Users],
-      type: "select"
+      options: Object.keys(filteredProductIcons),
+      mapping: filteredProductIcons
     }
   }
-};
+} as Meta;
 
 const Template: StoryFn<BreadcrumbProps> = args => (
   <Breadcrumb>


### PR DESCRIPTION
<!-- PR Checklist -->

# Description
This update improves the icon control for the Breadcrumb story. 
Before you could only select from 3 options. Now you can select from any ProductIcon.
I've filtered out the inverse versions of product icons because this story has a white background and I don't think we need to include those here otherwise it will look like nothing is displaying.


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Switch up some icons for the Breadcrumbs.
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
Before
<img width="1410" alt="Screenshot 2023-09-25 at 10 57 17 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/4eb36715-95b7-4fc1-bd8b-a7b2b058e51b">


After
<img width="1630" alt="Screenshot 2023-09-25 at 10 53 35 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/f3f7a9e7-90d3-4473-b7f7-8ccc0da62485">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
