### PR TITLE
docs: introduces spacing docs

### DIFF
--- a/.storybook/docs/stories/Spacing.stories.mdx
+++ b/.storybook/docs/stories/Spacing.stories.mdx
@@ -1,0 +1,74 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+import styled from "@emotion/styled";
+import {
+  spaceXxs,
+  spaceXs,
+  spaceS,
+  spaceM,
+  spaceL,
+  spaceXl,
+  spaceXxl,
+  themeBrandPrimary,
+  themeBorder,
+  borderRadiusDefault
+} from "../../../packages/design-tokens/build/js/designTokens";
+
+export const spacingSizes = [
+  { name: "spaceXxs", value: spaceXxs },
+  { name: "spaceXs", value: spaceXs },
+  { name: "spaceS", value: spaceS },
+  { name: "spaceM", value: spaceM },
+  { name: "spaceL", value: spaceL },
+  { name: "spaceXl", value: spaceXl },
+  { name: "spaceXxl", value: spaceXxl }
+];
+
+export const SpacingTable = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+  border-radius: ${borderRadiusDefault};
+  overflow: hidden;
+`;
+
+export const SpacingRow = styled.tr`
+  border-bottom: 1px solid ${themeBorder};
+`;
+
+export const SpacingCell = styled.td`
+  padding: ${spaceS};
+  color: ${themeBrandPrimary};
+  text-align: center;
+`;
+
+export const SizeExample = styled.div`
+  width: ${props => props.size};
+  height: ${props => props.size};
+  background-color: ${themeBrandPrimary};
+  border-radius: ${borderRadiusDefault};
+  margin: 0 auto;
+`;
+
+<Meta title="DesignTokens/Spacing" />
+
+# Spacing
+
+<SpacingTable>
+  <thead>
+    <tr>
+      <th>Design Token</th>
+      <th>Value</th>
+      <th>Size</th>
+    </tr>
+  </thead>
+  <tbody>
+    {spacingSizes.map((item, index) => (
+      <SpacingRow key={index}>
+        <SpacingCell>{item.name}</SpacingCell>
+        <SpacingCell>{item.value}</SpacingCell>
+        <SpacingCell>
+          <SizeExample size={item.value} />
+        </SpacingCell>
+      </SpacingRow>
+    ))}
+  </tbody>
+</SpacingTable>

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,6 +15,7 @@ const config: StorybookConfig = {
     "./docs/stories/Welcome.stories.mdx",
     "./docs/stories/Colors.stories.mdx",
     "./docs/stories/Typography.stories.mdx",
+    "./docs/stories/Spacing.stories.mdx",
     "../packages/**/*.stories.@(tsx|mdx)"
   ],
   // Optional


### PR DESCRIPTION
<!-- PR Checklist -->

# Description
This story adds a reference to our sizing design tokens, the values they represent, along with a visual representation of each.

When I speak with the design team we often talk in pixels and I have to translate that into our design tokens when building the UI. 
I have a notes app on my computer where I have a reference to each sizing token and the amount of px they are.

```
| spaceXxs         | 4px   |
| spaceXs          | 8px   |
| spaceS           | 12px  |
| spaceM           | 16px  |
| spaceL           | 24px  |
| spaceXl          | 32px  |
| spaceXxl         | 48px  |
```

My main hope is that this page will be a helpful reference for others,  and so these don't just have to live in my notes app. 
I think it's nice to see a visual representation of the scale. 

FYI Storybook has some built in styles for some of this like the table style.



<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
View the ✨new✨ Spacing Story. 

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
<img width="1671" alt="Screenshot 2023-09-27 at 8 21 23 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/d26d1063-db2f-41bd-8440-80a8d5d87a23">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
