### PR TITLE
chore(deps): bump downshift from 7.6.0 to 8.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@popperjs/core": "^2.11.8",
         "classnames": "^2.3.2",
         "copy-to-clipboard": "^3.3.3",
-        "downshift": "^7.6.0",
+        "downshift": "^8.2.2",
         "react-detect-click-outside": "^1.1.7",
         "react-focus-lock": "^2.9.5",
         "react-popper": "^2.3.0",
@@ -2152,11 +2152,11 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -14923,9 +14923,9 @@
       "dev": true
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
-      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -16594,27 +16594,29 @@
       }
     },
     "node_modules/downshift": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-      "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.2.2.tgz",
+      "integrity": "sha512-UmJHlNTzmFN3i427Hh9f1OXMnkhgSB/J+urC9ywabvwuftm0nB0/Utsb89OtDq+2UqyScQV4Ro7EM2PEV80N5w==",
       "dependencies": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^2.0.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
+        "@babel/runtime": "^7.22.15",
+        "compute-scroll-into-view": "^3.0.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
         "react": ">=16.12.0"
       }
     },
     "node_modules/downshift/node_modules/react-is": {
-      "version": "17.0.2",
-      "license": "MIT"
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/downshift/node_modules/tslib": {
-      "version": "2.4.0",
-      "license": "0BSD"
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -31792,9 +31794,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -37495,11 +37497,11 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "version": "7.23.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
+      "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -46533,9 +46535,9 @@
       }
     },
     "compute-scroll-into-view": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
-      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -47735,22 +47737,26 @@
       "dev": true
     },
     "downshift": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-      "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.2.2.tgz",
+      "integrity": "sha512-UmJHlNTzmFN3i427Hh9f1OXMnkhgSB/J+urC9ywabvwuftm0nB0/Utsb89OtDq+2UqyScQV4Ro7EM2PEV80N5w==",
       "requires": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^2.0.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
+        "@babel/runtime": "^7.22.15",
+        "compute-scroll-into-view": "^3.0.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "react-is": {
-          "version": "17.0.2"
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         },
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
@@ -58427,9 +58433,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@popperjs/core": "^2.11.8",
     "classnames": "^2.3.2",
     "copy-to-clipboard": "^3.3.3",
-    "downshift": "^7.6.0",
+    "downshift": "^8.2.2",
     "react-detect-click-outside": "^1.1.7",
     "react-focus-lock": "^2.9.5",
     "react-popper": "^2.3.0",

--- a/packages/popover/components/PopoverListItem.tsx
+++ b/packages/popover/components/PopoverListItem.tsx
@@ -28,7 +28,7 @@ export interface PopoverListItemProps extends React.HTMLProps<HTMLDivElement> {
   index: number;
   listLength: number;
   isActive?: boolean;
-  isSelected?: boolean;
+  isSelected?: boolean | null;
   "data-cy"?: string;
 }
 

--- a/packages/typeahead/components/Typeahead.tsx
+++ b/packages/typeahead/components/Typeahead.tsx
@@ -97,7 +97,9 @@ const Typeahead = ({
   delete textFieldProps.onFocus;
   delete textFieldProps.onClick;
 
-  const [menuWidth, setMenuWidth] = React.useState<number | null>(null);
+  const [menuWidth, setMenuWidth] = React.useState<number | undefined>(
+    undefined
+  );
 
   const containerRef = React.createRef<HTMLDivElement>();
 


### PR DESCRIPTION
# Description
- Currently, downshift version is [8.2.2](https://www.npmjs.com/package/downshift).
- Since the [width](https://github.com/d2iq/ui-kit/blob/main/packages/popover/components/PopoverBox.tsx#L33) accepts only `number | undefined` made changes accordingly to pass `undefined`.
- Since the is [Selected](https://github.com/d2iq/ui-kit/blob/main/packages/popover/components/PopoverListItem.tsx#L31) was accepting `boolean | undefined` made changes accordingly to pass `null` as we cannot changed the type of [selectedItem](https://github.com/d2iq/ui-kit/blob/main/packages/typeahead/components/Typeahead.tsx#L243) as it is coming from [downshift](https://github.com/downshift-js/downshift/blob/master/typings/index.d.ts#L11) library.

## Which issue(s) does this PR relate to?

https://github.com/d2iq/ui-kit/issues/985

## Testing

- Tested the `Typeahead` component locally which is using the `Downshift` library.

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
