### PR TITLE
Refactored the getHintContent to HintContent issue #1012

### DIFF
--- a/packages/shared/components/FormFieldWrapper.tsx
+++ b/packages/shared/components/FormFieldWrapper.tsx
@@ -49,7 +49,7 @@ const FormFieldWrapper = ({
       : "";
   };
 
-  const getHintContent = hintContent => {
+  function HintContent({ hintContent }) {
     return hintContent ? (
       <span
         id={getHintContentId()}
@@ -96,7 +96,7 @@ const FormFieldWrapper = ({
     <>
       {children({
         getValidationErrors: getValidationErrors(errors, formFieldWrapperId),
-        getHintContent: getHintContent(hintContent),
+        getHintContent: HintContent({ hintContent }),
         describedByIds: getDescribedBy(getHintContentId(), getErrorIds()),
         isValid: !errors || (errors && errors.length === 0)
       })}

--- a/packages/shared/components/FormFieldWrapper.tsx
+++ b/packages/shared/components/FormFieldWrapper.tsx
@@ -49,7 +49,7 @@ const FormFieldWrapper = ({
       : "";
   };
 
-  function HintContent({ hintContent }) {
+  const HintContent = ({ hintContent }) => {
     return hintContent ? (
       <span
         id={getHintContentId()}
@@ -63,7 +63,7 @@ const FormFieldWrapper = ({
         {hintContent}
       </span>
     ) : null;
-  }
+  };
 
   const getValidationErrors = (errors, formFieldWrapperId) => {
     if (!errors || (errors && errors.length === 0)) {

--- a/packages/shared/components/FormFieldWrapper.tsx
+++ b/packages/shared/components/FormFieldWrapper.tsx
@@ -63,7 +63,7 @@ const FormFieldWrapper = ({
         {hintContent}
       </span>
     ) : null;
-  };
+  }
 
   const getValidationErrors = (errors, formFieldWrapperId) => {
     if (!errors || (errors && errors.length === 0)) {


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

We have a shared component called FormFieldWrapper. There are some parts of it that use old patterns that we'd like to update.
There are these get getter type functions that return JSX. Really these should be components that return JSX in accordance with modern patters.

This would would be to assess those parts of FormFieldWrapper and refactor and improve them.

For example, this getHintContent, should be a component called HintContent

## Which issue(s) does this PR relate to?


## Testing

test the FormFieldWrapper component

## Trade-offs



## Screenshots


![CodeBefore](https://github.com/d2iq/ui-kit/assets/112269684/546ea8f6-0760-470a-83a9-eb26ba4b966c)
![CodeAfter](https://github.com/d2iq/ui-kit/assets/112269684/56bc5beb-ef87-4c85-9ac6-3f59c2e7940d)

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
