### PR TITLE
feat: new outline button components

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -10,6 +10,7 @@ There are several types of buttons to choose from based on the intended action:
 | --------------- | ------------------------------------------------------------------------------- |
 | Primary         | Used for the most important call-to-action on a page, such as Save or Deploy.   |
 | Secondary       | Used primarily for a call-to-action that is a link.                             |
+| Outline         | Used as an alternative secondary button with an outline/ghost style.            |
 | Warning         | Used to advise caution.                                                         |
 | Danger          | Used to highlight something dangerous that can't be undone, such as "Delete".   |
 | Icon only       | Use when an icon is enough to represent the action, such as "Create a Service". |

--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -30,7 +30,8 @@ export enum ButtonAppearances {
   Standard = "standard",
   Danger = "danger",
   Success = "success",
-  Warning = "warning"
+  Warning = "warning",
+  Outline = "outline"
 }
 
 export interface ButtonProps extends LinkProps {

--- a/packages/button/components/OutlineButton.tsx
+++ b/packages/button/components/OutlineButton.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import {
+  default as ButtonBase,
+  ButtonProps,
+  ButtonAppearances
+} from "./ButtonBase";
+
+const OutlineButton = (props: ButtonProps) => (
+  <ButtonBase
+    appearance={ButtonAppearances.Outline}
+    data-cy={props["data-cy"] ?? "outlineButton"}
+    {...props}
+  />
+);
+
+export default OutlineButton;

--- a/packages/button/components/OutlineDropdownButton.tsx
+++ b/packages/button/components/OutlineDropdownButton.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import OutlineButton from "./OutlineButton";
+import { ButtonProps } from "./ButtonBase";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+
+const OutlineDropdownButton = (props: ButtonProps) => (
+  <OutlineButton
+    iconEnd={SystemIcons.TriangleDown}
+    data-cy={props["data-cy"] ?? "outlineDropdownButton"}
+    {...props}
+  />
+);
+
+export default OutlineDropdownButton;

--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -4,6 +4,7 @@ export { default as StandardButton } from "./components/StandardButton";
 export { default as SuccessButton } from "./components/SuccessButton";
 export { default as DangerButton } from "./components/DangerButton";
 export { default as WarningButton } from "./components/WarningButton";
+export { default as OutlineButton } from "./components/OutlineButton";
 
 export { default as PrimaryDropdownButton } from "./components/PrimaryDropdownButton";
 export { default as SecondaryDropdownButton } from "./components/SecondaryDropdownButton";
@@ -11,5 +12,6 @@ export { default as StandardDropdownButton } from "./components/StandardDropdown
 export { default as SuccessDropdownButton } from "./components/SuccessDropdownButton";
 export { default as WarningDropdownButton } from "./components/WarningDropdownButton";
 export { default as DangerDropdownButton } from "./components/DangerDropdownButton";
+export { default as OutlineDropdownButton } from "./components/OutlineDropdownButton";
 
 export { default as ResetButton } from "./components/ResetButton";

--- a/packages/button/stories/DefaultButton.stories.tsx
+++ b/packages/button/stories/DefaultButton.stories.tsx
@@ -6,7 +6,8 @@ import {
   StandardButton,
   SuccessButton,
   DangerButton,
-  WarningButton
+  WarningButton,
+  OutlineButton
 } from "../..";
 import { action } from "@storybook/addon-actions";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
@@ -17,6 +18,7 @@ export default {
   component: StandardButton,
   subComponents: {
     PrimaryButton,
+    OutlineButton,
     SecondaryButton,
     SuccessButton,
     DangerButton,
@@ -57,6 +59,10 @@ export const _PrimaryButton = {
 
 export const _SecondaryButton = {
   render: args => <SecondaryButton {...args}>{args.children}</SecondaryButton>
+};
+
+export const _OutlineButton = {
+  render: args => <OutlineButton {...args}>{args.children}</OutlineButton>
 };
 
 export const _SuccessButton = {

--- a/packages/button/stories/DropdownButton.stories.tsx
+++ b/packages/button/stories/DropdownButton.stories.tsx
@@ -6,7 +6,8 @@ import {
   StandardDropdownButton,
   SuccessDropdownButton,
   WarningDropdownButton,
-  DangerDropdownButton
+  DangerDropdownButton,
+  OutlineDropdownButton
 } from "../../index";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
@@ -46,6 +47,12 @@ export const _PrimaryDropdownButton = {
 export const _SecondaryDropdownButton = {
   render: args => (
     <SecondaryDropdownButton {...args}>{args.children}</SecondaryDropdownButton>
+  )
+};
+
+export const _OutlineDropdownButton = {
+  render: args => (
+    <OutlineDropdownButton {...args}>{args.children}</OutlineDropdownButton>
   )
 };
 

--- a/packages/button/style.ts
+++ b/packages/button/style.ts
@@ -18,7 +18,10 @@ import {
   themeErrorInverted,
   themeTextColorDisabledInverted,
   themeWarningInverted,
-  themeWarning
+  themeWarning,
+  purpleLighten5,
+  purpleLighten4,
+  themeBgPrimary
 } from "../design-tokens/build/js/designTokens";
 import { darken, getTextColor } from "../shared/styles/color";
 import { ButtonAppearances } from "./components/ButtonBase";
@@ -70,6 +73,7 @@ export const filledButton = (
 
 const mutedButton = css`
   ${tintContent(themeTextColorDisabled)};
+  border-color: ${themeBgDisabled};
   cursor: default;
   pointer-events: none;
 
@@ -196,6 +200,26 @@ export const focusStyleByAppearance = (appearance, isInverse) => {
       return isInverse
         ? focusStyles(getHoverColor(getCSSVarValue(themeWarningInverted)))
         : focusStyles(getHoverColor(getCSSVarValue(themeWarning)));
+    case "outline":
+      return css`
+        ${(isInverse
+          ? focusStyles(
+              getCSSVarValue(themeBgPrimary),
+              getHoverColor(getCSSVarValue(themeTextColorInteractiveInverted))
+            )
+          : getCSSVarValue(themeBgPrimary),
+        focusStyles(getHoverColor(getCSSVarValue(themeTextColorInteractive))))};
+        &:focus {
+          background-color: ${purpleLighten5};
+
+          &:after {
+            bottom: -4px;
+            left: -4px;
+            right: -4px;
+            top: -4px;
+          }
+        }
+      `;
     default:
       return "";
   }
@@ -251,6 +275,32 @@ export const button = appearance => {
         getHoverColor(getCSSVarValue(themeWarning)),
         getActiveColor(getCSSVarValue(themeWarning))
       );
+    case "outline":
+      return css`
+        border: 1px solid ${getCSSVarValue(themeTextColorInteractive)};
+        border-radius: ${borderRadiusDefault};
+        padding: ${buttonPadding.vert} ${buttonPadding.horiz};
+
+        ${tintContent(themeTextColorInteractive)};
+
+        &:hover {
+          background-color: ${purpleLighten5};
+          ${tintContent(
+            getHoverColor(getCSSVarValue(themeTextColorInteractive))
+          )};
+        }
+        &:active {
+          background-color: ${purpleLighten4};
+          ${tintContent(
+            getActiveColor(getCSSVarValue(themeTextColorInteractive))
+          )};
+        }
+        &[href],
+        &[href]:visited {
+          background-color: ${purpleLighten4};
+          ${tintContent(themeTextColorInteractive)};
+        }
+      `;
     default:
       return "";
   }
@@ -306,6 +356,26 @@ export const buttonInverse = appearance => {
         getHoverColor(getCSSVarValue(themeWarningInverted)),
         getActiveColor(getCSSVarValue(themeWarningInverted))
       );
+    case "outline":
+      return css`
+        border: 1px solid ${getCSSVarValue(themeTextColorInteractiveInverted)};
+        ${tintContent(themeTextColorInteractiveInverted)};
+
+        &:hover {
+          ${tintContent(
+            getHoverColor(getCSSVarValue(themeTextColorInteractiveInverted))
+          )};
+        }
+        &:active {
+          ${tintContent(
+            getActiveColor(getCSSVarValue(themeTextColorInteractiveInverted))
+          )};
+        }
+        &[href],
+        &[href]:visited {
+          ${tintContent(themeTextColorInteractiveInverted)};
+        }
+      `;
     default:
       return "";
   }

--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
   background-color: var(--themeBgDisabled, #E8EAED);
@@ -273,6 +274,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
 }
@@ -491,6 +493,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
   background-color: var(--themeBgDisabled, #E8EAED);
@@ -714,6 +717,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
   background-color: var(--themeBgDisabled, #E8EAED);
@@ -937,6 +941,7 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
   background-color: var(--themeBgDisabled, #E8EAED);
@@ -1160,6 +1165,7 @@ exports[`ButtonBase renders all appearances with props 6`] = `
   width: 100%;
   color: var(--themeTextColorDisabled, #AEB0B4);
   fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
   cursor: default;
   pointer-events: none;
   background-color: var(--themeBgDisabled, #E8EAED);
@@ -1182,6 +1188,246 @@ exports[`ButtonBase renders all appearances with props 6`] = `
 
 .emotion-1:active {
   background-color: #c78220;
+}
+
+.emotion-1:hover,
+.emotion-1:focus,
+.emotion-1:active {
+  color: var(--themeTextColorDisabled, #AEB0B4);
+  fill: var(--themeTextColorDisabled, #AEB0B4);
+}
+
+.emotion-1:hover,
+.emotion-1:focus,
+.emotion-1:active {
+  background-color: var(--themeBgDisabled, #E8EAED);
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-2>div {
+  width: auto;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+  display: inherit;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-4 use {
+  pointer-events: none;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+  padding-left: 8px;
+}
+
+.emotion-5:after {
+  content: "...";
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+  display: inherit;
+  padding-left: 4px;
+}
+
+<button
+    aria-haspopup="true"
+    class="emotion-0 emotion-1"
+    disabled=""
+    tabindex="0"
+    type="submit"
+  >
+    <span
+      class="emotion-2"
+    >
+      <span
+        class="emotion-3"
+      >
+        <svg
+          aria-label="system-check icon"
+          class="emotion-4"
+          data-cy="icon"
+          height="16"
+          preserveAspectRatio="xMinYMin meet"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <use
+            xlink:href="#system-check"
+          />
+        </svg>
+      </span>
+      <span
+        class="emotion-5"
+      >
+        Button
+      </span>
+      <span
+        class="emotion-6"
+      >
+        <svg
+          aria-label="system-check icon"
+          class="emotion-4"
+          data-cy="icon"
+          height="16"
+          preserveAspectRatio="xMinYMin meet"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <use
+            xlink:href="#system-check"
+          />
+        </svg>
+      </span>
+    </span>
+  </button>
+</DocumentFragment>
+`;
+
+exports[`ButtonBase renders all appearances with props 7`] = `
+<DocumentFragment>
+  .emotion-0 {
+  outline: none;
+  position: relative;
+}
+
+.emotion-0:focus {
+  background-color: #704fe5;
+}
+
+.emotion-0:focus:after {
+  border: 2px solid #704fe5;
+  border-radius: 4px;
+  bottom: -3px;
+  content: "";
+  left: -3px;
+  position: absolute;
+  right: -3px;
+  top: -3px;
+}
+
+.emotion-0:focus {
+  background-color: #F8F6FF;
+}
+
+.emotion-0:focus:after {
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  top: -4px;
+}
+
+.emotion-1 {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  text-align: inherit;
+  border: 1px solid #7D58FF;
+  border-radius: 4px;
+  padding: 10px 18px;
+  color: var(--themeTextColorInteractive, #7D58FF);
+  fill: var(--themeTextColorInteractive, #7D58FF);
+  cursor: pointer;
+  display: inline-block;
+  outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  text-align: center;
+  width: 100%;
+  color: var(--themeTextColorDisabled, #AEB0B4);
+  fill: var(--themeTextColorDisabled, #AEB0B4);
+  border-color: var(--themeBgDisabled, #E8EAED);
+  cursor: default;
+  pointer-events: none;
+  background-color: var(--themeBgDisabled, #E8EAED);
+}
+
+.emotion-1::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.emotion-1:hover {
+  background-color: #F8F6FF;
+  color: #704fe5;
+  fill: #704fe5;
+}
+
+.emotion-1:active {
+  background-color: #E5DDFF;
+  color: #6446cc;
+  fill: #6446cc;
+}
+
+.emotion-1[href],
+.emotion-1[href]:visited {
+  background-color: #E5DDFF;
+  color: var(--themeTextColorInteractive, #7D58FF);
+  fill: var(--themeTextColorInteractive, #7D58FF);
 }
 
 .emotion-1:hover,

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -30,12 +30,14 @@ export {
   SuccessButton,
   DangerButton,
   WarningButton,
+  OutlineButton,
   PrimaryDropdownButton,
   SecondaryDropdownButton,
   StandardDropdownButton,
   SuccessDropdownButton,
   WarningDropdownButton,
   DangerDropdownButton,
+  OutlineDropdownButton,
   ResetButton
 } from "./button";
 export { ButtonCard, Card, LinkCard } from "./card";


### PR DESCRIPTION
Introduces a new OutlineButton component,
along with an OutlineDropdownButton.

Closes D2IQ-99363

<!-- PR Checklist -->

# Description

2 New Components
- `OutlineButton`
- `OutlineDropdownButton`

We wanted to introduce this new OutlineButton to serve as a secondary button, for example there are locations in the UI where we'd like to place it next to a PrimaryButton.
Outline buttons are a good choice when you want to emphasize an action or choice without overwhelming the user. They're less visually dominant than solid, filled buttons, which is why they are commonly used for secondary or less important actions on a page. We were missing a "ghost" or outline type button from our set of buttons, so this will be a nice addition to our UI Kit. 

The default should have a white background as requested by design, this ensures it has the same level of readable on any background. The explicitly set background color makes it different from a ghost button which would have a transparent background. 

_Button Design Spec_ 
<img width="634" alt="Screenshot 2023-09-11 at 4 11 04 PM (1)" src="https://github.com/d2iq/ui-kit/assets/34781875/fff8e26d-0ec3-4e87-b289-f95988b786ac">


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
 - https://jira.d2iq.com/browse/D2IQ-99363
 
## Testing
Test out the new buttons and all of their various states with the controls panel in Storybook. 

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->


## Screenshots

### OutlineButton
<img width="1385" alt="Screenshot 2023-10-19 at 1 57 30 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/cbf1167b-f9d5-4557-af65-0f194841acbb">


### OutlineDropdownButton
<img width="1386" alt="Screenshot 2023-10-19 at 1 57 44 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/56215a3a-4561-4938-a386-2f1601992204">


### Button States

**Disabled + with an iconStart and iconEnd**
<img width="1729" alt="Screenshot 2023-10-19 at 10 48 30 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/13b2bc26-abec-42db-8857-03979d9cfb2e">

**Default** 
<img width="160" alt="Screenshot 2023-10-19 at 10 47 08 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/07da0487-c76e-42b9-802b-1237808b2a5d">

**Hover**
<img width="123" alt="Screenshot 2023-10-19 at 1 56 33 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/94531408-27c7-4721-9695-4d01e424ec48">

**Active**
<img width="154" alt="Screenshot 2023-10-19 at 10 49 53 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/74923cc3-c82f-4335-8dca-25abfb5c6e37">

**Focus**
<img width="144" alt="Screenshot 2023-10-19 at 10 50 13 AM" src="https://github.com/d2iq/ui-kit/assets/34781875/d73674c4-a8b9-4170-b477-306e6a77e7d9">

**Active + Focus while clicking**
<img width="150" alt="Screenshot 2023-10-19 at 1 53 42 PM" src="https://github.com/d2iq/ui-kit/assets/34781875/9ac402a0-d6c4-4b9c-b504-1c82e355f68e">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [x] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
